### PR TITLE
Fix anchor link for finding item ids and attributes in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 - <a href=https://github.com/Aris-t2/CustomCSSforFx/#webextensions-can-not-modify-browsers-appearance-in-firefox-57>WebExtensions can not modify browsers appearance in Firefox 57+</a></br>
 - <a href=https://github.com/Aris-t2/CustomCSSforFx/#where-to-find-firefox-profile-folder-and-what-is-the-correct-location-for-user-styles>Where to find Firefox profile folder and what is the correct location for user styles?</a></br>
 - <a href=https://github.com/Aris-t2/CustomCSSforFx/#how-to-use-custom-user-styles>How to use custom user styles?</a></br>
-- <a href=https://github.com/Aris-t2/CustomCSSforFx/#how-to-find-ids-and-attributes>How to find ids and attributes?</a></br>
+- <a href=https://github.com/Aris-t2/CustomCSSforFx/#how-to-find-item-ids-and-attributes>How to find ids and attributes?</a></br>
 - <a href=https://github.com/Aris-t2/CustomCSSforFx/#how-to-modify-custom-user-styles>How to modify custom user styles?</a></br>
 - <a href=https://github.com/Aris-t2/CustomCSSforFx/#suggested-ui-tweaks>Suggested ui tweaks</a></br>
 - <a href=https://github.com/Aris-t2/CustomCSSforFx/#aboutconfig-tweaks>'about:config' tweaks</a></br>


### PR DESCRIPTION
Just a little change in the readme to fix the link for "- How to find ids and attributes?" 