### PR TITLE
Another choice tabs width

### DIFF
--- a/classic/css/tabs/tab_maxwidth_fornotebook.css
+++ b/classic/css/tabs/tab_maxwidth_fornotebook.css
@@ -5,18 +5,8 @@
 /* by Aris (aris-addons@gmx.net)*********************************************************/
 /* Github: https://github.com/aris-t2/customcssforfx ************************************/
 /****************************************************************************************/
-
-/* use 'about:config > browser.tabs.tabMinWidth' for tab min-width *//*
-.tabbrowser-tab:not([pinned]) {
-  min-width: 50px !important;
-  clip-width: 50px !important;
+.tabbrowser-tab[fadein]:not([pinned])
+{
+  min-width: 40px !important;
+  max-width: 50px !important;
 }
-*/
-
-/* tab max-width */
-.tabbrowser-tab[fadein]:not([pinned]) {
-  max-width: 120px !important;
-  overflow: hidden !important;
-}
-
-/**/


### PR DESCRIPTION
- There is a way to separate the favicon from the title (inside the tab) ?
- It's possible to increase the favicon size ?
I ignore.
It's might be better to purpose a second choice. Because you know the people are able to identify (associate, etc) a website just with a logo (picture, etc).
Another reason it will help because the space screen is very limited (that's true for a laptop, etc). Sometimes the people want to open a lot of website at once (let's say twenty, etc).

Yes it could be a little trouble when the website doesn't have a favicon. But you could enable it (by default if it isn't already the case ? Sorry I don't remember everything).

PS : No I don't have it (close button tabs)