### PR TITLE
Add default_tabs_static_tab_line.css to disable tab line animation

### DIFF
--- a/classic/css/tabs/default_tabs_static_tab_line.css
+++ b/classic/css/tabs/default_tabs_static_tab_line.css
@@ -1,0 +1,8 @@
+/* Firefox Quantum userChrome.css tweaks ************************************************/
+/* Github: https://github.com/aris-t2/customcssforfx ************************************/
+/****************************************************************************************/
+
+
+.tab-line {
+  transition: none !important;
+}

--- a/classic/userChrome.css
+++ b/classic/userChrome.css
@@ -299,6 +299,7 @@
 /* @import url(./css/tabs/default_tabs_tab_background_appearance.css); /**/
 /* tab line settings - only use one at a time ***************************************************/
 /* @import url(./css/tabs/default_tabs_no_tab_line.css); /**/
+/* @import url(./css/tabs/default_tabs_static_tab_line.css); /**/
 /* @import url(./css/tabs/default_tabs_tab_line_purple_in_private_mode.css); /**/
 
 /* other tab settings ***************************************************************************/


### PR DESCRIPTION
This eliminates the animation used by tab lines on the default tabs, causing them to appear or disappear instantly.