### PR TITLE
screenshots_alternative_save_ui.css fix for FF60

### DIFF
--- a/classic/css/webcontent/screenshots_alternative_save_ui.css
+++ b/classic/css/webcontent/screenshots_alternative_save_ui.css
@@ -2,63 +2,58 @@
 /* Github: https://github.com/aris-t2/customcssforfx ************************************/
 /****************************************************************************************/
 
+body > div.preview-overlay > div.preview-image > div.preview-buttons {
+  align-items: stretch !important;
+}
 
-/* rtl locales flip button boxes direction, so there is no need to use -moz-padding/margin-start/end etc. */
-
-/* Screenshots add-ons add a dir="ltr"/"rtl" to html tag. Using direction tags will cause this code to affect less sites. */
-
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download  {
+/* Save-Button */
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download  {
+  background-color: #1a0 !important;
   width: initial !important;
-  padding-left: 34px !important;
   background-position: 8px center !important;
   border: none !important;
 }
 
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download img,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download img  {
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download  {
   margin-bottom: -3px !important;
-  margin-left: -28px !important;
-  margin-right: 6px !important;
-  width: 18px !important;
+  width: initial !important;
+  display: flex !important;
 }
 
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download  {
-  background-color: #1a0 !important;
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download img {
+  width: 20px !important;
+  padding-right: 5px !important;
 }
 
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download:hover,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download:hover {
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download:hover {
   background-color: #2b0 !important;
 }
 
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save,
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save {
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
+  content: attr(title) !important;
+  font-weight: bold !important;
+}
+
+/* Cloud-Button */
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save {
   background-color: #C00 !important;
   color: #C00 !important;
   font-size: 0 !important;
 }
 
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save:hover,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save:hover,
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save:hover,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save:hover {
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save:hover,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save:hover {
   background-color: #D22 !important;
 }
 
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: attr(title) !important;
   font-weight: bold !important;
 }
 
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after,
-html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Cloud" !important;
   font-size: medium !important;
   color: white !important;
@@ -67,64 +62,64 @@ html[dir="rtl"] > body > div.highlight > div.highlight-buttons > button.highligh
 
 /* Language settings */
 /* English US*/
-html[dir="ltr"][lang="en-US"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+html[lang="en-US"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Save" !important;
 }
-html[dir="ltr"][lang="en-US"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"][lang="en-US"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+html[lang="en-US"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="en-US"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Upload" !important;
 }
 
 /* German */
-html[dir="ltr"][lang="de"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+html[lang="de"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Speichern" !important;
 }
-html[dir="ltr"][lang="de"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"][lang="de"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+html[lang="de"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="de"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Hochladen" !important;
 }
 
 /* French */
-html[dir="ltr"][lang="fr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+html[lang="fr"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Sauvegarder" !important;
 }
-html[dir="ltr"][lang="fr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"][lang="fr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+html[lang="fr"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="fr"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Télécharger" !important;
 }
 
 /* Spanish */
-html[dir="ltr"][lang="es-ES"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+html[lang="es-ES"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Salvar" !important;
 }
-html[dir="ltr"][lang="es-ES"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"][lang="es-ES"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+html[lang="es-ES"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="es-ES"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Subir" !important;
 }
 
 /* Portuguese */
-html[dir="ltr"][lang="pt-PT"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+html[lang="pt-PT"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Salve" !important;
 }
-html[dir="ltr"][lang="pt-PT"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"][lang="pt-PT"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+html[lang="pt-PT"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="pt-PT"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Envio" !important;
 }
 
 /* Italian */
-html[dir="ltr"][lang="it"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+html[lang="it"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Salvare" !important;
 }
-html[dir="ltr"][lang="it"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"][lang="it"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+html[lang="it"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="it"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Caricare" !important;
 }
 
 /* Russian */
-html[dir="ltr"][lang="ru"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download::after {
+html[lang="ru"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Сохранить" !important;
 }
-html[dir="ltr"][lang="ru"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.preview-button-save::after,
-html[dir="ltr"][lang="ru"] > body > div.highlight > div.highlight-buttons > button.highlight-button-cancel + button.highlight-button-copy + button.highlight-button-download + button.highlight-button-save::after {
+html[lang="ru"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="ru"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Загрузить" !important;
 }

--- a/classic/css/webcontent/screenshots_alternative_save_ui.css
+++ b/classic/css/webcontent/screenshots_alternative_save_ui.css
@@ -15,9 +15,9 @@ body > div.preview-overlay > div.preview-image > div.preview-buttons > button.hi
   width: initial !important;
   background-position: 8px center !important;
   border: none !important;
-  margin-bottom: -3px !important;
   width: initial !important;
   display: flex !important;
+  font-size: 0 !important;
 }
 
 body > div.highlight > div.highlight-buttons > button.highlight-button-download:hover,
@@ -29,6 +29,7 @@ body > div.highlight > div.highlight-buttons > button.highlight-button-download:
 body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: attr(title) !important;
   font-weight: bold !important;
+  font-size: 18px !important;
 }
 
 body > div.highlight > div.highlight-buttons > button.highlight-button-download img,
@@ -54,7 +55,7 @@ body > div.preview-overlay > div.preview-image > div.preview-buttons > button.pr
 body > div.highlight > div.highlight-buttons > button.highlight-button-save::after ,
 body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Cloud" !important;
-  font-size: medium !important;
+  font-size: 18px !important;
   color: white !important;
   font-weight: bold !important;
 }

--- a/classic/css/webcontent/screenshots_alternative_save_ui.css
+++ b/classic/css/webcontent/screenshots_alternative_save_ui.css
@@ -2,58 +2,57 @@
 /* Github: https://github.com/aris-t2/customcssforfx ************************************/
 /****************************************************************************************/
 
+body > div.highlight > div.highlight-buttons,
 body > div.preview-overlay > div.preview-image > div.preview-buttons {
   align-items: stretch !important;
+  flex-wrap: wrap !important;
 }
 
 /* Save-Button */
+body > div.highlight > div.highlight-buttons > button.highlight-button-download,
 body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download  {
   background-color: #1a0 !important;
   width: initial !important;
   background-position: 8px center !important;
   border: none !important;
-}
-
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download  {
   margin-bottom: -3px !important;
   width: initial !important;
   display: flex !important;
 }
 
+body > div.highlight > div.highlight-buttons > button.highlight-button-download:hover,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download:hover {
+  background-color: #2b0 !important;
+}
+
+body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
+  content: attr(title) !important;
+  font-weight: bold !important;
+}
+
+body > div.highlight > div.highlight-buttons > button.highlight-button-download img,
 body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download img {
   width: 20px !important;
   padding-right: 5px !important;
 }
 
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download:hover {
-  background-color: #2b0 !important;
-}
-
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
-  content: attr(title) !important;
-  font-weight: bold !important;
-}
 
 /* Cloud-Button */
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save,
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save {
+body > div.highlight > div.highlight-buttons > button.highlight-button-save,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save {
   background-color: #C00 !important;
   color: #C00 !important;
   font-size: 0 !important;
 }
 
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save:hover,
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save:hover {
+body > div.highlight > div.highlight-buttons > button.highlight-button-save:hover,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save:hover {
   background-color: #D22 !important;
 }
 
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
-  content: attr(title) !important;
-  font-weight: bold !important;
-}
-
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
-body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
+body > div.highlight > div.highlight-buttons > button.highlight-button-save::after ,
+body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Cloud" !important;
   font-size: medium !important;
   color: white !important;
@@ -62,64 +61,71 @@ body > div.preview-overlay > div.preview-image > div.preview-buttons > button.hi
 
 /* Language settings */
 /* English US*/
+html[lang="en-US"] > body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
 html[lang="en-US"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Save" !important;
 }
-html[lang="en-US"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
+html[lang="en-US"] > body > div.highlight > div.highlight-buttons > button.highlight-button-save::after,
 html[lang="en-US"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
   content: "Upload" !important;
 }
 
 /* German */
+html[lang="de"] > body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
 html[lang="de"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Speichern" !important;
 }
-html[lang="de"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
-html[lang="de"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
+html[lang="de"] > body > div.highlight > div.highlight-buttons > button.highlight-button-save::after,
+html[lang="de"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Hochladen" !important;
 }
 
 /* French */
+html[lang="fr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
 html[lang="fr"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Sauvegarder" !important;
 }
-html[lang="fr"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
-html[lang="fr"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
+html[lang="fr"] > body > div.highlight > div.highlight-buttons > button.highlight-button-save::after,
+html[lang="fr"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Télécharger" !important;
 }
 
 /* Spanish */
+html[lang="es-ES"] > body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
 html[lang="es-ES"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Salvar" !important;
 }
-html[lang="es-ES"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
-html[lang="es-ES"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
+html[lang="es-ES"] > body > div.highlight > div.highlight-buttons > button.highlight-button-save::after,
+html[lang="es-ES"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Subir" !important;
 }
 
 /* Portuguese */
+html[lang="pt-PT"] > body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
 html[lang="pt-PT"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Salve" !important;
 }
-html[lang="pt-PT"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
-html[lang="pt-PT"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
+html[lang="pt-PT"] > body > div.highlight > div.highlight-buttons > button.highlight-button-save::after,
+html[lang="pt-PT"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Envio" !important;
 }
 
 /* Italian */
+html[lang="it"] > body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
 html[lang="it"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Salvare" !important;
 }
-html[lang="it"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
-html[lang="it"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
+html[lang="it"] > body > div.highlight > div.highlight-buttons > button.highlight-button-save::after,
+html[lang="it"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Caricare" !important;
 }
 
 /* Russian */
+html[lang="ru"] > body > div.highlight > div.highlight-buttons > button.highlight-button-download::after,
 html[lang="ru"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-download::after {
   content: "Сохранить" !important;
 }
-html[lang="ru"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after,
-html[lang="ru"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.highlight-button-save::after {
+html[lang="ru"] > body > div.highlight > div.highlight-buttons > button.highlight-button-save::after,
+html[lang="ru"] > body > div.preview-overlay > div.preview-image > div.preview-buttons > button.preview-button-save::after {
   content: "Загрузить" !important;
 }


### PR DESCRIPTION
Html structure changed in FF60, needed fix.
`ltr / rtl` is definitely unnecessary by now as the selectors are concatenated gaplessly and rather unique in that way.