### PR TITLE
align bookmark toolbar items in middle vertically, same as separators

### DIFF
--- a/classic/css/toolbars/bookmarks_toolbar_multiple_lines.css
+++ b/classic/css/toolbars/bookmarks_toolbar_multiple_lines.css
@@ -65,6 +65,7 @@
   padding-bottom: 0px !important;
   margin-top: 2px !important;
   margin-bottom: 2px !important;
+  vertical-align: middle;
 }
 /*
 #personal-bookmarks #PlacesToolbar toolbarbutton.bookmark-item:hover:active:not([disabled="true"]),

--- a/classic/css/toolbars/bookmarks_toolbar_multiple_lines_fx66.css
+++ b/classic/css/toolbars/bookmarks_toolbar_multiple_lines_fx66.css
@@ -84,6 +84,7 @@
   padding-bottom: 0px !important;
   margin-top: 2px !important;
   margin-bottom: 2px !important;
+  vertical-align: middle;
 }
 /*
 #personal-bookmarks #PlacesToolbar toolbarbutton.bookmark-item:hover:active:not([disabled="true"]),


### PR DESCRIPTION
Aligning bookmark items and separators in the middle vertically, looks better.