### PR TITLE
add ac_popup_with_two_lines_fx70

### DIFF
--- a/classic/config/general_variables.css
+++ b/classic/config/general_variables.css
@@ -67,6 +67,11 @@
   --ac_popup_height: auto !important;  /* replace auto with 'calc(47.5px * var(--ac_popup_number_of_results))' to get a shorter scrollable list for high result numbers */
 }
 
+/* for ac_popup_with_two_lines_fx70.css */
+:root {
+  --ac_popup_number_of_results_fx70: 7; /* how many results to show before overflowing to scroll */
+}
+
 :root[sizemode="maximized"] {
   --ac_popup_width: 1400px !important; /* popup width in maximized mode */
 }

--- a/classic/css/locationbar/ac_popup_with_two_lines_fx70.css
+++ b/classic/css/locationbar/ac_popup_with_two_lines_fx70.css
@@ -1,0 +1,44 @@
+:root {
+  --ac_popup_maxheight: calc((2.6875em * 1.05 + 12px) * var(--ac_popup_number_of_results_fx70) - 6px);
+}
+
+#urlbar-results .urlbarView-row {
+  height: 2.6875em !important;
+}
+.urlbarView-row-inner {
+  flex-wrap: wrap !important;
+}
+#urlbar-results .urlbarView-title {
+  height: 1.2em;
+}
+#urlbar-results .urlbarView-title-separator {
+  flex-basis: 100%;
+  height: 0;
+  display: block !important;
+}
+#urlbar-results .urlbarView-title-separator:before {
+  content: '' !important;
+}
+.urlbarView-secondary {
+  left: 48px;
+  top: 0.5em;
+  position: relative;
+  font-size: 0.85em;
+}
+.urlbarView-row[type="search"]:not([selected]):not(:hover) > .urlbarView-row-inner > .urlbarView-title-separator,
+.urlbarView-row[type="search"]:not([selected]):not(:hover) > .urlbarView-row-inner > .urlbarView-action {
+  visibility: visible !important;
+}
+
+#urlbarView-results {
+  max-height: var(--ac_popup_maxheight) !important;
+}
+
+#urlbar-results > .urlbarView-body-outer {
+  overflow-x: hidden !important;
+}
+#urlbar-results > .urlbarView-body-outer,
+#urlbar-results scrollbox,
+#urlbar-results > .urlbarView-body-outer {
+  overflow-y: auto !important;
+}

--- a/classic/userChrome.css
+++ b/classic/userChrome.css
@@ -718,6 +718,8 @@
 /* @import "./css/locationbar/ac_popup_classic_with_url_only_fx68.css"; /**/
 /* @import "./css/locationbar/ac_popup_classic_with_two_lines_fx68_star_at_the_end.css"; /**/  /* <--- old autocomplete popup for Fx 68+ & star icon at the end */
 /* @import "./css/locationbar/ac_popup_classic_with_url_only_fx68_star_at_the_end.css"; /**/
+/* [!] - Firefox 70+: new-style popup with two-line, scrollable results *************************/
+/* @import "./css/locationbar/ac_popup_with_two_lines_fx70.css"; /**/
 
 /* result menuitem settings/appearance **********************************************************/
 /* @import "./css/locationbar/ac_popup_firefox_background_logo.css"; /**/


### PR DESCRIPTION
This adds a two-lines mode for Firefox 70+ (with quantumbar; not tested with earlier versions & without quantumbar).

It doesn't change colors or width of the popup. Only make titles and urls display on seperate lines.