### PR TITLE
[tabs] fix the multiline tabbar for FF71+

### DIFF
--- a/classic/css/tabs/tabs_multiple_lines_v4.css
+++ b/classic/css/tabs/tabs_multiple_lines_v4.css
@@ -1,0 +1,102 @@
+/* Firefox Quantum userChrome.css tweaks ************************************************/
+/* Github: https://github.com/aris-t2/customcssforfx ************************************/
+/****************************************************************************************/
+
+
+/****************************************************************************************/
+/* multirow / multiple tab lines - modified for CustomCSSforFx **************************/
+/* all credits go to the original authors: **********************************************/
+/* https://www.reddit.com/r/FirefoxCSS/comments/7dclp7/multirow_tabs_in_ff57/ ***********/
+/* https://github.com/MrOtherGuy/firefox-csshacks/blob/master/chrome/multi-row_tabs.css */
+/****************************************************************************************/
+
+
+/* NOTE  ********************************************************************************/
+/* Variables are set inside '.\config\' folders CSS files, if complete package is used! */
+
+:root{
+  --tabs-lines: 3;
+  --tab_min_width_mlt: 80px;
+  --tab_max_width_mlt: 200px;
+  --tab-min-height_mlt: var(--tab-min-height,32px); /* set own value here, if used without configuration files */
+}
+
+#tabbrowser-tabs{
+  min-height: unset !important;
+  padding-inline-start: 0px !important
+}
+
+/* Selectors for Firefox 71+ */
+/* These are not tabs toolbar specific but horizontal scrollbox isn't used elsewhere, except in bookmarks toolbar but there it doesn't have [part] attribute since it's not in shadow-root */
+@-moz-document url(chrome://browser/content/browser.xhtml){
+  .scrollbutton-up[orient="horizontal"][part]~spacer,
+  .scrollbutton-up[orient="horizontal"][part],
+  .scrollbutton-down[orient="horizontal"][part]{ display: none }
+
+  scrollbox[part][orient="horizontal"]{
+    display: flex;
+    flex-wrap: wrap;
+    overflow-y: auto;
+    max-height: calc(var(--tab-min-height_mlt) * var(--tabs-lines));
+    scrollbar-color: currentColor transparent;
+    scrollbar-width: thin;
+  }
+}
+
+/* Test for Firefox > 66 */
+@supports (inset-block:auto){
+  #tabbrowser-tabs > .tabbrowser-arrowscrollbox > .arrowscrollbox-scrollbox{
+    display: flex;
+    flex-wrap: wrap;
+    overflow-y: auto;
+    max-height: calc(var(--tab-min-height_mlt) * var(--tabs-lines));
+    scrollbar-color: var(--toolbar-bgcolor) var(--lwt-accent-color);
+    scrollbar-width: thin;
+  }
+  #tabbrowser-tabs > .tabbrowser-arrowscrollbox {
+    overflow: -moz-hidden-unscrollable;
+    display: block;
+  }
+}
+
+/* Test for Firefox < 66 */
+@supports not (inset-block:auto){
+  #tabbrowser-tabs > .tabbrowser-arrowscrollbox{
+    min-height: unset !important;
+  }
+  #tabbrowser-tabs .scrollbox-innerbox{
+    display: flex;
+    flex-wrap: wrap;
+  }
+  #tabbrowser-tabs .arrowscrollbox-scrollbox {
+    overflow: -moz-hidden-unscrollable;
+    display: block;
+  }
+}
+
+.tabbrowser-tab{ height: var(--tab-min-height_mlt); }
+
+#tabbrowser-tabs .tabbrowser-tab[pinned]{
+  position: static !important;
+  margin-inline-start: 0px !important;
+}
+
+.tabbrowser-tab[fadein]:not([pinned]){
+  flex-grow: 1;
+  min-width: var(--tab_min_width_mlt) !important;
+  max-width: var(--tab_max_width_mlt) !important;
+  /*
+  Uncomment to enable full-width tabs, also makes tab dragging a tiny bit more sensible
+  Don't set to none or you'll see errors in console when closing tabs
+  */
+  /*max-width: 100vw !important;*/
+}
+
+.tabbrowser-tab > stack{ width: 100%; height: 100% }
+
+#tabbrowser-tabs .scrollbutton-up,
+#tabbrowser-tabs .scrollbutton-down,
+#alltabs-button,
+:root:not([customizing]) #TabsToolbar #new-tab-button,
+#tabbrowser-tabs spacer,
+.tabbrowser-tab::after{ display: none !important }

--- a/classic/userChrome.css
+++ b/classic/userChrome.css
@@ -428,6 +428,7 @@
 /* @import "./css/tabs/tabs_multiple_lines_v2.css"; /**/  /* <--- EXPERIMENTAL */
 /* @import "./css/tabs/tabs_multiple_lines_v3.css"; /**/  /* <--- EXPERIMENTAL */
 /* @import "./css/tabs/tabs_multiple_lines_v3_force_newtab_button_visibility.css"; /**/  /* <--- EXPERIMENTAL */
+/* @import "./css/tabs/tabs_multiple_lines_v4.css"; /**/  /* <--- EXPERIMENTAL */
 
 /* TAB TITLE IN FIREFOX TITLEBAR (Windows only) *************************************************/
 /* [!] some internal pages only show default browser title **************************************/


### PR DESCRIPTION
The multiple lines tab bar has been broken in FF71+ due migrate to shadow dom. MrOtherGuy has found the solution for this issue.
![Screenshot from 2019-10-17 10-23-49](https://user-images.githubusercontent.com/20357500/66986817-4566c800-f0c8-11e9-93cf-4e4090d2b440.png)
