### PR TITLE
Even More AppButton Icons (DevTools)

### DIFF
--- a/classic/css/appbutton/appbutton_popup_more_icons.css
+++ b/classic/css/appbutton/appbutton_popup_more_icons.css
@@ -2,25 +2,24 @@
 /* Github: https://github.com/aris-t2/customcssforfx ************************************/
 /****************************************************************************************/
 
-
 #appMenu-open-file-button {
   -moz-context-properties: fill;
-  list-style-image: url(chrome://browser/skin/open.svg);
+  list-style-image: url("chrome://browser/skin/open.svg");
 }
 
 #appMenu-save-file-button {
   -moz-context-properties: fill;
-  list-style-image: url(chrome://browser/skin/save.svg);
+  list-style-image: url("chrome://browser/skin/save.svg");
 }
 
 #appMenu-more-button {
   -moz-context-properties: fill;
-  list-style-image: url(chrome://browser/skin/chevron.svg);
+  list-style-image: url("chrome://browser/skin/chevron.svg");
 }
 
 #appMenu-developer-button  {
   -moz-context-properties: fill;
-  list-style-image: url(chrome://browser/skin/developer.svg);
+  list-style-image: url("chrome://browser/skin/developer.svg");
 }
 
 :-moz-any(#appMenu-open-file-button,#appMenu-save-file-button,#appMenu-more-button,#appMenu-developer-button) .toolbarbutton-text  {
@@ -29,4 +28,113 @@
 
 #main-window:-moz-lwtheme:-moz-lwtheme-brighttext :-moz-any(#appMenu-open-file-button,#appMenu-save-file-button,#appMenu-more-button,#appMenu-developer-button) {
   fill: currentColor !important;
+}
+
+/* Even More AppButton Icons: DevTools by Key */
+
+#PanelUI-developerItems toolbarbutton[key="key_inspector"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-inspector.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_webconsole"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-webconsole.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_jsdebugger"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-debugger.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_netmonitor"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-network.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_styleeditor"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-styleeditor.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_performance"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-profiler.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_storage"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-storage.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_accessibility"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-accessibility.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_application"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-application.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_dom"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-dom.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_browserConsole"] image.toolbarbutton-icon {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-webconsole.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_viewSource"] image.toolbarbutton-icon { /* ReUsing the DOM icon since I expect everyone uses the Inspector instead */
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://devtools/skin/images/tool-dom.svg");
+}
+
+#PanelUI-developerItems toolbarbutton[key="key_inspector"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_webconsole"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_jsdebugger"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_netmonitor"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_styleeditor"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_performance"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_storage"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_accessibility"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_application"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_dom"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_browserConsole"] label.toolbarbutton-text,
+#PanelUI-developerItems toolbarbutton[key="key_viewSource"] label.toolbarbutton-text {
+
+	padding-inline-start: 8px !important;
+}
+
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_inspector"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_webconsole"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_jsdebugger"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_netmonitor"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_styleeditor"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_performance"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_storage"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_accessibility"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_application"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_dom"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_browserConsole"] image.toolbarbutton-icon,
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton[key="key_viewSource"] image.toolbarbutton-icon {
+
+	fill: currentColor !important;
+}
+
+/* Get More DevTools (by Name (English Only)) */
+
+#PanelUI-developerItems toolbarbutton image.toolbarbutton-icon[label="Get More Tools"] {
+	-moz-context-properties: fill;
+	 list-style-image: url("chrome://browser/skin/developer.svg");
+ }
+
+#PanelUI-developerItems toolbarbutton label.toolbarbutton-text[value="Get More Tools"] {
+	padding-inline-start: 8px !important;
+}
+
+#main-window:-moz-lwtheme:-moz-lwtheme-brighttext #PanelUI-developerItems toolbarbutton image.toolbarbutton-icon[label="Get More Tools"] {
+	fill: currentColor !important;
 }


### PR DESCRIPTION
Added all the DevTools icons. Managed to get them by KEY so it should be multi-language (except "More Tools" which unfortunately is by label). ReUsed the DOM icon for Source and the Console icon is used for both consoles. Added quotes to your list-images (syntax highlighting friendly lol).