### PR TITLE
Darnit there was a bug with the Responsive Design Icon!

### DIFF
--- a/classic/css/appbutton/appbutton_popup_more_icons.css
+++ b/classic/css/appbutton/appbutton_popup_more_icons.css
@@ -93,7 +93,8 @@
 }
 
 #PanelUI-developerItems toolbarbutton[key="key_responsiveDesignMode"] > image.toolbarbutton-icon {
-	-moz-context-properties: fill;
+	-moz-context-properties: fill, fill-opacity;
+	 fill-opacity: 0;
 	 list-style-image: url("chrome://devtools/skin/images/command-responsivemode.svg");
 }
 


### PR DESCRIPTION
@Acid-Crash discovered the Responsive Design icon was supposed to look like a cellphone, and not a black square! Lol, it needs opacity set to zero. Now I have to update my icons in Menu Icon Plus too! Sorry about that.