### PR TITLE
Rewrote/restructured the `userChrome.css` file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,16 +1,115 @@
-<b>READ THIS BEFORE POSTING A NEW ISSUE REPORT</b>  
-
+**READ THIS BEFORE POSTING A NEW ISSUE REPORT**
 
 1. This is a SUPPORT AREA for features CustomCSSforFx provides.
-2. This is not a 'request' area for new stuff or legacy add-on features. Do not open a new issue about something this project does not offer. Instead join the 'General discussions, feedback, questions belong here' thread to ask questions about what is or could be possible with CSS.
+2. This is not a 'request' area for new stuff or legacy add-on features. Do not open a new
+issue about something this project does not offer. Instead join the 'General
+discussions, feedback, questions belong here' thread to ask questions about
+what is or could be possible with CSS.
 3. Read 'how to report issues properly' before posting a new issue.
 --> https://github.com/Aris-t2/CustomCSSforFx/issues/4
 4. Verify there are no '@namespace' references anywhere in your custom code.
 5. Use available support threads:
-- GENERAL DISCUSSIONS, FEEDBACK, QUESTIONS --> https://github.com/Aris-t2/CustomCSSforFx/discussions/454
-- MULTIROW TABS SUPPORT THREAD --> https://github.com/Aris-t2/CustomCSSforFx/discussions/455
+- GENERAL DISCUSSIONS, FEEDBACK, QUESTIONS -->
+  https://github.com/Aris-t2/CustomCSSforFx/discussions/454
+- MULTIROW TABS SUPPORT THREAD -->
+  https://github.com/Aris-t2/CustomCSSforFx/discussions/455
 
-<b>IMPORTANT</b>   
-By submitting a new issue you confirm having read and understood the above and all 'how to report a new issue' instructions.
-Invalid issue reports will get closed without further notice to keep this projects support area clean.  
-Thanks for understanding.
+**IMPORTANT**
+ By submitting a new issue you confirm having read and understood
+the above and all 'how to report a new issue' instructions as well as guidelines specified below. 
+Invalid issue reports will get closed without further notice to keep this projects support
+area clean. Thanks for understanding.
+
+
+# `userChrome.css` formating guidelines
+
+If you wish to extend / update the userChrome.css file you are required to
+follow the established guidelines. Otherwise your patch may not be accepted. 
+
+## Comments
+
+Comments are the most important part of our repositories userChrome.css
+configuration as they dictate which files are to be included (or not). It is
+crucial to keep informative, section declaring and 'disabling' comments
+seperate to maintain readability and the ease of visual parsing of the file.
+
+All lines except the ones that denote enabled stylesheets must be a comment
+and formatted as described below.
+
+Single line comments follow `/* this convention */` and important single line
+comments can also look like 
+
+    /*
+     * This!
+     */
+
+Multiline comments are to be formatted as follows: 
+ 
+    /* This is a regular multiline comment.  It should contain proper english
+     * sentences beginning with capital letters.
+     */
+
+Reason: css uses C-like comments and that is the proper commenting style for C. Additionally the row of asterisks helps in distinguishing them from other content.
+
+Some comments like section headings include additional rules.
+
+## Table of Contents
+ 
+The Table of Contents is a multiline comment, a series of sections seperated by
+`seperator lines`, that is lines containing only[^1] hypens (55 of them to be
+exact, just copy them to save the hassle). Each *SECTION* is named with one or
+more uppercase words and is declared with `[N] <SECTION_NAME>` where N is a
+number one higher than the previous section's number and `<SECTION_NAME>` is of
+course its name. Subsections are declared on following lines, indented with a
+tab character and prepended with a dash (`-`). Higher level subsections are
+further indented. An example section declaration might look like this: 
+
+    ...
+    * -----------------------...
+    * [7] TAB BAR
+    * 	- tab background 
+    * 		- variants
+    * 	- tab foreground
+    * -----------------------...
+    ...
+
+## Sections (Categories)
+
+If your wish to create a new SECTION for your stylesheet and have already added
+it to the [Table of Contents](#table of contents), append it to the end of the
+file using this syntax:
+
+    /* ================
+     * SECTION NAME [N]
+     * ================
+     */
+
+Subsections follow the same convention except equal signs are replaced with
+hyphens (`-`).
+
+## Entries
+
+The section heading should be followed by a line containing the `/* ON | OFF
+*/` label which should be aligned with the switches (`/**/`) of the entries.
+Entries are your `@import` rules. Each disabled entry begins with 4
+spaces followed by a toggle / lock (`/*/`) allowing the user to enable your entry
+when removed. Enabled entries therefore begin directly on a new line without
+anything prepending them e.g.:
+    
+    /* disabled */
+        /*/ @import('foo/bar/stylesheet.css') /**/
+    /* enabled */
+    @import('foo/bar/...')               /**/
+
+Each entry MUST end with a 'switch' (`/**/`) to maintain clear visual
+indication of user-selected entries when paired with 'labels' (`/* ON | OFF
+*/`) AND each switch must be aligned with the previous ones as well as the labels.
+
+
+*important notes*: 
+IF a section is particularly long, make sure a `/* ON | OFF */` label occurs
+every 40 lines or so to ensure easy visual parsing of enabled / disabled
+stylesheets when scrolling through the file. Format it properly so that it
+alignes with the switches (`/**/`) of previous `@import`s.
+
+[^1]: Except for the ` *`.

--- a/classic/userChrome.css
+++ b/classic/userChrome.css
@@ -1,673 +1,878 @@
-/* Firefox userChrome.css tweaks ****************************************************************/
-/* Based on 'Classic Theme Restorer' & 'Classic Toolbar Buttons' add-ons CSS code ***************/
-/* Github: https://github.com/aris-t2/customcssforfx ********************************************/
-/************************************************************************************************/
+/* Firefox userChrome.css tweaks 
+ * Github: https://github.com/aris-t2/customcssforfx */
 
-/************************************************************************************************/
-/* Custom CSS for Firefox 91+ *******************************************************************/
-/* Version 4.1.8 ********************************************************************************/
-/************************************************************************************************/
+/*
+ * Custom CSS for Firefox 91+ 
+ * Version 4.1.8 
+ * 
+ * Change-log: https://github.com/Aris-t2/CustomCSSforFx/commits/
+ *
+ * [!] Firefox requires the following preference to be enabled for custom styles to be loaded:
+ *
+ * 	'about:config > toolkit.legacyUserProfileCustomizations.stylesheets > true'
+ * 
+ * you can access firefox preferences by typing `about:config` into the url bar
+ */
 
-/*************************************************************************************************
+/*
+ *                  <===l==|===>
+ *           <|=x=x==| README |===x=x=|>
+ *                  <=|======|=>
+ * 
+ * To find the profile folder type `about:support` into firefox's url bar 
+ * and navigate to: `Profile Folder > Open Folder`.
+ *
+ * Create a `/chrome/` (chrome) directory (folder) in the profile folder 
+ * you just opened and paste in the files found here so it looks like this:
+ * 
+ * /chrome/config/
+ * /chrome/css/
+ * /chrome/image/
+ * /chrome/userChrome.css
+ * /chrome/userContent.css
+ *
+ * To ACTIVE an option: remove /*/ before '@import'.
+ * To DEACTIVATE an option: add /*/ before '@import' (and indent it nicely :>).
+ *
+ * ``` 
+ *                             /* ON | OFF */
+ * @import "foo/bar.css"       /**/
+ *     /*/ @import "foo/bar.css"       /**/ 
+ * /*   ^--- toggle */
+ * ```
+ *
+ * MacOS specific code: look for 'macOS fix' additions inside this file.
+ * EXPERIMENTAL settings are for testing only!
+ */
 
-  Change-log: https://github.com/Aris-t2/CustomCSSforFx/commits/
+/* /=========================\
+ * |    TABLE OF CONTENTS    |
+ * \=========================/
+ * 
+ * CONFIGURATION FILES
+ * 	- general variables / color variables (default browser theme only)
+ *
+ * -------------------------------------------------------
+ * [1] TOOLBAR BUTTONS
+ * 	- toolbar button / icon appearance
+ * 	- bookmarks menu button / popup
+ * 	- other button settings
+ * 	- custom BACK and FORWARD buttons appearance [1.3]
+ * 	- APPLICATION/HAMBURGER BUTTON
+ * 		- visibility / popup
+ * 		- buttons appearance on navigation toolbar / in Firefox titlebar
+ * -------------------------------------------------------
+ * [2] TABS
+ * 	- custom tab appearance / old squared tabs
+ * 	- TABS TOOLBAR POSITION
+ * 		- below titlebar / navigation and bookmarks toolbar / main content
+ * 	- TAB TEXT - colors/shadow/weight/style for default/active/hovered/pending tabs
+ * 	- MULTIROW / multi lined tabs
+ * 	- empty tab favicon / custom tab loading animation / tab close icon settings
+ * 	- settings for DEFAULT TABS / other tab settings
+ * -------------------------------------------------------
+ * [3] GENERAL UI
+ * 	- general settings / close icons / page context menu items
+ * 	- overflow menu / sidebar / findbar
+ * 	- SEARCHBAR
+ *  		- general settings for default search
+ * -------------------------------------------------------
+ * [4] TOOLBARS
+ * 	- ADDONS BAR (simulated bottoms toolbar)
+ * 	- GENERAL TOOLBAR settings
+ * 		- toolbar context menu settings
+ * 	- MENUBAR settings
+ * 	- bookmarks toolbar settings
+ * 	- BOOKMARKS TOOLBAR - MULTIPLE LINES
+ * 	- AeroGlass TOOLBARS / WIN10 fix for GLASS8
+ * 	- TOOLBAR TEXT MODES
+ * 		- icons+text / text only
+ * -------------------------------------------------------
+ * [5] LOCATION BAR / urlbar / mega bar
+ * 	- general location bar tweaks / identity box / padlock icons icon/button tweaks
+ * 	- 'autocomplete popup' appearance / result item settings/appearance
+ * -------------------------------------------------------
+ *
+ *
+ * CONFIGURATION FILES - edit target files to change general values *
+ */
 
-  [!] Firefox requires this preference to be enabled or custom styles will not be loaded:
-	'about:config > toolkit.legacyUserProfileCustomizations.stylesheets > true'
+/* =====================
+ * GENERAL VARIABLES
+ * =====================
+ */
 
-*************************************************************************************************/
+/* [!] set global variables for font and tab size options and more inside target file */
 
-/*************************************************************************************************
-
-  README
-
-  Profile folder: address bar > about:support > Profile Folder > Open Folder
-  
-  CSS files and sub-folders belong into \PROFILEFOLDER\chrome\ directory.
-  \chrome\config\
-  \chrome\css\
-  \chrome\image\
-  \chrome\userChrome.css
-  \chrome\userContent.css
-
-  ACTIVE option: remove /* before '@import'
-  DEACTIVATE option: add /* before '@import'
-
-  macOS specific code -> look for 'macOS fix' additions inside this file
-
-  EXPERIMENTAL settings are for testing only!
-
-  BASIC OVERVIEW - settings this file contains:
-  CONFIGURATION FILES
-  - general variables / color variables (default browser theme only)
-  TOOLBAR BUTTONS
-  - toolbar button / icon appearance
-  - bookmarks menu button / popup
-  - other button settings
-  - custom BACK and FORWARD buttons appearance
-  - APPLICATION/HAMBURGER BUTTON
-  -- visibility / popup
-  -- buttons appearance on navigation toolbar / in Firefox titlebar
-  TABS
-  - custom tab appearance / old squared tabs
-  - TABS TOOLBAR POSITION
-  -- below titlebar / navigation and bookmarks toolbar / main content
-  - TAB TEXT - colors/shadow/weight/style for default/active/hovered/pending tabs
-  - MULTIROW / multi lined tabs
-  - empty tab favicon / custom tab loading animation / tab close icon settings
-  - settings for DEFAULT TABS / other tab settings
-  GENERAL UI
-  - general settings / close icons / page context menu items
-  - overflow menu / sidebar / findbar
-  - SEARCHBAR
-  -- general settings for default search
-  TOOLBARS
-  - ADDONS BAR (simulated bottoms toolbar)
-  - GENERAL TOOLBAR settings
-  -- toolbar context menu settings
-  - MENUBAR settings
-  - bookmarks toolbar settings
-  - BOOKMARKS TOOLBAR - MULTIPLE LINES
-  - AeroGlass TOOLBARS / WIN10 fix for GLASS8
-  - TOOLBAR TEXT MODES
-  -- icons+text / text only
-  LOCATION BAR / urlbar / mega bar
-  - general location bar tweaks / identity box / padlock icons icon/button tweaks
-  - 'autocomplete popup' appearance / result item settings/appearance
-
-
-*************************************************************************************************/
-
-/************************************************************************************************/
-/* CONFIGURATION FILES - edit target files to change general values *****************************/
-/************************************************************************************************/
-
-/* GENERAL VARIABLES ****************************************************************************/
-/* [!] set global variables for font and tab size options and more inside target file ***********/
 @import "./config/general_variables.css"; /**/
 
-/* COLOR VARIABLES FOR DEFAULT BROWSER THEME ONLY - MAIN UI - [only use one at a time] **********/
-/* [!] set own colors for tabs & toolbars inside 'color_variables.css' or use available presets */
-/* [!] enabled 'menubar_color.css' and 'statusbar_color.css' might be required in some cases ****/
-@import "./config/color_variables.css"; /**/  /* <- default 'grey' colors */
-/* @import "./config/color_variables_aero.css"; /**/  /* <- 'AeroBlue' colors (Win 7 Aero) */
-/* @import "./config/color_variables_classic-grey.css"; /**/  /* <- 'classic grey' colors (Win Classic) */
-/* @import "./config/color_variables_fx3.css"; /**/  /* <- 'Firefox 3-like' blueish colors */
-/* @import "./config/color_variables_transparent.css"; /**/  /* <- (semi-)'transparent' colors */
-/* @import "./config/color_variables_aeroglass.css"; /**/  /* <- 'AeroGlass' colors / Win10+Glass8 fix can be found in 'toolbars' area */
-/* @import "./config/color_variables_deved.css"; /**/  /* <- based on 'Developer Edition' colors */
-/* @import "./config/color_variables_noia4_grey.css"; /**/  /* <- based on 'Noia 4 themes' grey colors */
-/* @import "./config/color_variables_noia4_lightgrey.css"; /**/  /* <- based on 'Noia 4 themes' lightgrey colors */
-/* @import "./config/color_variables_noia4_dark.css"; /**/  /* <- based on 'Noia 4 themes' dark colors */
+/* COLOR VARIABLES FOR DEFAULT BROWSER THEME ONLY - MAIN UI - [only use one at a time]
+ * [!] set own colors for tabs & toolbars inside 'color_variables.css' or use available presets
+ * [!] enabled 'menubar_color.css' and 'statusbar_color.css' might be required in some cases
+ */
 
-/* Darker "Dark" default theme - [only use one at a time] ***************************************/
-/* @import "./css/toolbars/default_dark_theme_darker.css"; /**/
-/* @import "./css/toolbars/default_dark_theme_darker_v2.css"; /**/
+                                                                        / ON | OFF /
+    /* default 'grey' colors */
+@import "./config/color_variables.css";                                  /**/  
 
-/* CUSTOM SCROLLBARS VARIABLES - EXPERIMENTAL ***************************************************/
-/* [!] Might not work on every page! This issue is for Mozilla to solve. ************************/
-/* [!] Not compatible with custom scrollbar JavaScript userChrome scripts. **********************/
-/* [!] Custom size values only compatible with 'web content' scrollbars at the moment. **********/
-/* [!] More info inside 'custom_scrollbar_appearance.css' file. *********************************/
-/* @import "./config/custom_scrollbar_appearance.css"; /**/		/* <--- EXPERIMENTAL */
+    /*/ 'AeroBlue' colors (Win 7 Aero) */
+    /*/ @import "./config/color_variables_aero.css";                          /**/  
+
+    /*/ 'classic grey' colors (Win Classic) */
+    /*/ @import "./config/color_variables_classic-grey.css";                  /**/  
+    
+    /* 'Firefox 3-like' blueish colors */
+    /*/ @import "./config/color_variables_fx3.css";                           /**/  
+    
+    /* (semi-)'transparent' colors */
+    /*/ @import "./config/color_variables_transparent.css";                   /**/  
+    
+    /* 'AeroGlass' colors / Win10+Glass8 fix can be found in 'toolbars' area */
+    /*/ @import "./config/color_variables_aeroglass.css";                     /**/  
+    
+    /* based on 'Developer Edition' colors */
+    /*/ @import "./config/color_variables_deved.css";                         /**/  
+    
+    /* based on 'Noia 4 themes' grey colors */
+    /*/ @import "./config/color_variables_noia4_grey.css";                    /**/  
+    
+    /* based on 'Noia 4 themes' lightgrey colors */
+    /*/ @import "./config/color_variables_noia4_lightgrey.css";               /**/  
+    
+    /* based on 'Noia 4 themes' dark colors */
+    /*/ @import "./config/color_variables_noia4_dark.css";                    /**/  
+    
+    /* Darker "Dark" default theme - [only use one at a time]  *
+    /*/ @import "./css/toolbars/default_dark_theme_darker.css";               /**/
+    /*/ @import "./css/toolbars/default_dark_theme_darker_v2.css";            /**/
 
 
-/************************************************************************************************/
-/* TOOLBAR BUTTONS ******************************************************************************/
-/************************************************************************************************/
+/* CUSTOM SCROLLBARS VARIABLES - EXPERIMENTAL
+ * 	[!] Might not work on every page! This issue is for Mozilla to solve.
+ * 	[!] Not compatible with custom scrollbar JavaScript userChrome scripts.
+ * 	[!] Custom size values only compatible with 'web content' scrollbars at the moment.
+ * 	[!] More info inside 'custom_scrollbar_appearance.css' file.
+ */
 
-/* icon appearance - [only use one at a time] (custom icons do not scale in HiDPI modes) ********/
-/* [!] custom icons sets do not offer modern download progress animations on purpose! ***********/
-/* [!] disable button badge indicator with the 'option' below custom icon sets ******************/
-@import "./css/buttons/icons_colorized.css"; /**/
-/* @import "./css/buttons/icons_white_icons.css"; /**/
-/* @import "./css/buttons/icons_custom_icons.css"; /**/  /* aka "Mozilla Mix" from CTB */
-/* @import "./css/buttons/icons_custom_icons_fx1.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_fx2.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_fx3.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_fx3strata.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_fx12_colorized.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_crystal.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_firebird.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_kempelton.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_noia.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_ie6.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_seamonkey.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_old_chrome.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_old_osx.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_tango.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_fx45.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_fx45_inverted.css"; /**/
+/* <--- EXPERIMENTAL */
+                                                         /* ON | OFF */
+    /*/ @import "./config/custom_scrollbar_appearance.css";     /**/
 
-/* 'classic' pre-Proton button padding **********************************************************/
-/* @import "./css/buttons/classic_button_padding.css"; /**/
+/* ===================
+ * TOOLBAR BUTTONS [1]
+ * ===================
+ */
 
-/* navigation toolbar buttons appearance - [only use one at a time] *****************************/
-@import "./css/buttons/buttons_on_navbar_classic_appearance.css"; /**/
-/* @import "./css/buttons/buttons_on_navbar_classic_appearance_v2.css"; /**/
-/* @import "./css/buttons/buttons_on_navbar_classic_appearance_dark.css"; /**/		/* <--- good for Dark themes */
-/* @import "./css/buttons/buttons_on_navbar_aero_appearance.css"; /**/
-/* @import "./css/buttons/buttons_on_navbar_windows_classic_theme_appearance.css"; /**/
-/* @import "./css/buttons/buttons_on_navbar_glass_appearance.css";			/* <--- good for Dark themes */
-/* @import "./css/buttons/buttons_on_navbar_osx_appearance.css"; /**/
+/* icon appearance - [only use one at a time] (custom icons do not scale in HiDPI modes)
+ * [!] custom icons sets do not offer modern download progress animations on purpose!
+ * [!] disable button badge indicator with the 'option' below custom icon sets
+ */
+                                                                                       /* ON | OFF */
 
-/* navigation toolbar buttons - button roundness (edit file to set different roundness) *********/
-/* @import "./css/buttons/buttons_on_navbar_button_roundness.css"; /**/
+@import "./css/buttons/icons_colorized.css";                                             /**/
+    /*/ @import "./css/buttons/icons_white_icons.css";                                        /**/
+    /*/ @import "./css/buttons/icons_custom_icons.css";                                       /**/  
+    /*/ aka "Mozilla Mix" from CTB */
+    /*/ @import "./css/buttons/icons_custom_icons_fx1.css";                                   /**/
+    /*/ @import "./css/buttons/icons_custom_icons_fx2.css";                                   /**/
+    /*/ @import "./css/buttons/icons_custom_icons_fx3.css";                                   /**/
+    /*/ @import "./css/buttons/icons_custom_icons_fx3strata.css";                             /**/
+    /*/ @import "./css/buttons/icons_custom_icons_fx12_colorized.css";                        /**/
+    /*/ @import "./css/buttons/icons_custom_icons_crystal.css";                               /**/
+    /*/ @import "./css/buttons/icons_custom_icons_firebird.css";                              /**/
+    /*/ @import "./css/buttons/icons_custom_icons_kempelton.css";                             /**/
+    /*/ @import "./css/buttons/icons_custom_icons_noia.css";                                  /**/
+    /*/ @import "./css/buttons/icons_custom_icons_ie6.css";                                   /**/
+    /*/ @import "./css/buttons/icons_custom_icons_seamonkey.css";                             /**/
+    /*/ @import "./css/buttons/icons_custom_icons_old_chrome.css";                            /**/
+    /*/ @import "./css/buttons/icons_custom_icons_old_osx.css";                               /**/
+    /*/ @import "./css/buttons/icons_custom_icons_tango.css";                                 /**/
+    /*/ @import "./css/buttons/icons_custom_icons_fx45.css";                                  /**/
+    /*/ @import "./css/buttons/icons_custom_icons_fx45_inverted.css";                         /**/
 
-/* squared buttons / button size - [only use one at a time] *************************************/
-/* "rectangular shape" - normal size ************************************************************/
-/* @import "./css/buttons/buttons_on_navbar_squared_buttons.css"; /**/
-/* "normal shape" - large size (huge 48x48px buttons with 36x36px icons) ************************/
-/* [!] not compatible with 'custom icon' options ************************************************/
-/* [!] not compatible with 'custom back & forward buttons' appearance options *******************/
-/* [!] not compatible with 'text mode' option ***************************************************/
-/* [!] partly compatible with 'icons+text' option, if in 'compact mode' *************************/
-/* @import "./css/buttons/buttons_on_navbar_huge_48px_size.css"; /**/			/* <--- EXPERIMENTAL */
 
-/* smaller button spaces in 'compact' mode - 'Classic Toolbar Buttons' add-ons 'small' mode *****/
-/* [!] 'compact mode' got hidden behind the about:config switch browser.compactmode.show ********/
-/* @import "./css/buttons/buttons_on_navbar_more_compact_mode.css"; /**/
+/* -----------------------------------
+ * 'Classic' pre-Proton button padding 
+ * -----------------------------------
+ */
+                                                                                         /* ON | OFF */
+    /*/ @import "./css/buttons/classic_button_padding.css";                                       /**/
 
-/* bookmarks toolbar - buttons appearance - [only use one at a time] ****************************/
-/* @import "./css/buttons/buttons_on_bookmarks_toolbar_old_size_and_appearance.css"; /**/  /* Windows 7-10 only */
-/* @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance.css"; /**/
-/* @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance_dark.css"; /**/
-/* @import "./css/buttons/buttons_on_bookmarks_toolbar_aero_appearance.css"; /**/
+    /* navigation toolbar buttons appearance - [only use one at a time]
+@import "./css/buttons/buttons_on_navbar_classic_appearance.css";                         /**/
+    /*/ @import "./css/buttons/buttons_on_navbar_classic_appearance_v2.css";                      /**/
 
-/* bookmarks toolbar - bookmark items appearance - [only use one at a time] *********************/
-/* @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance_items.css"; /**/
-/* @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance_items_dark.css"; /**/
-/* @import "./css/buttons/buttons_on_bookmarks_toolbar_aero_appearance_items.css"; /**/
+    /* V--- good for Dark themes ---V*/
+    /*/ @import "./css/buttons/buttons_on_navbar_classic_appearance_dark.css";                    /**/
+    /*/ @import "./css/buttons/buttons_on_navbar_aero_appearance.css";                            /**/
+    /*/ @import "./css/buttons/buttons_on_navbar_windows_classic_theme_appearance.css";           /**/
 
-/* menubar - toolbar button appearance **********************************************************/
-/* @import "./css/buttons/buttons_on_menubar_toolbar_classic_appearance.css"; /**/
+    /* V--- good for Dark themes ---V */
+    /*/ @import "./css/buttons/buttons_on_navbar_glass_appearance.css";			
+    /*/ @import "./css/buttons/buttons_on_navbar_osx_appearance.css";                             /**/
+    
+    /* navigation toolbar buttons - button roundness (edit file to set different roundness)
+    /*/ @import "./css/buttons/buttons_on_navbar_button_roundness.css";                           /**/
+    
+    /* squared buttons / button size - [only use one at a time]
+    /* "rectangular shape" - normal size
+    /*/ @import "./css/buttons/buttons_on_navbar_squared_buttons.css";                            /**/
 
-/* tabs toolbar - toolbar button appearance *****************************************************/
-/* @import "./css/buttons/buttons_on_tabs_toolbar_classic_appearance.css"; /**/			/* <--- EXPERIMENTAL */
+/* "normal shape" - large size (huge 48x48px buttons with 36x36px icons)
+ * [!] not compatible with 'custom icon' options
+ * [!] not compatible with 'custom back & forward buttons' appearance options
+ * [!] not compatible with 'text mode' option
+ * [!] partly compatible with 'icons+text' option, if in 'compact mode'
+ */
 
-/* bookmarks menu button - 'button & popup' appearance ******************************************/
+/* <--- EXPERIMENTAL */
+    /*/ @import "./css/buttons/buttons_on_navbar_huge_48px_size.css";                                 /**/ 
+
+/* smaller button spaces in 'compact' mode - 'Classic Toolbar Buttons' add-ons 'small' mode
+ * [!] 'compact mode' got hidden behind the about:config switch browser.compactmode.show
+ */
+
+    /*/ @import "./css/buttons/buttons_on_navbar_more_compact_mode.css"; /**/
+
+/* bookmarks toolbar - buttons appearance - [only use one at a time]
+
+/* Windows 7-10 only */
+                                                                                           /* ON | OFF */
+
+    /*/ @import "./css/buttons/buttons_on_bookmarks_toolbar_old_size_and_appearance.css";         /**/  
+    /*/ @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance.css";              /**/
+    /*/ @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance_dark.css";         /**/
+    /*/ @import "./css/buttons/buttons_on_bookmarks_toolbar_aero_appearance.css";                 /**/
+    
+    /*/ bookmarks toolbar - bookmark items appearance - [only use one at a time]
+    /*/ @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance_items.css";        /**/
+    /*/ @import "./css/buttons/buttons_on_bookmarks_toolbar_classic_appearance_items_dark.css";   /**/
+    /*/ @import "./css/buttons/buttons_on_bookmarks_toolbar_aero_appearance_items.css";           /**/
+
+/* menubar - toolbar button appearance
+
+    /*/ @import "./css/buttons/buttons_on_menubar_toolbar_classic_appearance.css"; /**/
+
+/* tabs toolbar - toolbar button appearance
+
+/* <--- EXPERIMENTAL */
+/* @import "./css/buttons/buttons_on_tabs_toolbar_classic_appearance.css"; /**/			
+
+/* bookmarks menu button - 'button & popup' appearance
+                                                                                        /* ON | OFF */
+
 @import "./css/buttons/bookmarks_menu_button_localized_label_on_bookmarks_toolbar.css"; /**/
-/* @import "./css/buttons/bookmarks_menu_button_popup_showall_top_hidden.css"; /**/
-/* @import "./css/buttons/bookmarks_menu_button_popup_showall_bottom_hidden.css"; /**/
-/* @import "./css/buttons/bookmarks_menu_button_popup_sidebar_item_hidden.css"; /**/
-/* @import "./css/buttons/bookmarks_menu_button_popup_toolbar_item_hidden.css"; /**/
-/* @import "./css/buttons/bookmarks_menu_button_popup_other_item_hidden.css"; /**/
+    /*/ @import "./css/buttons/bookmarks_menu_button_popup_showall_top_hidden.css";             /**/
+    /*/ @import "./css/buttons/bookmarks_menu_button_popup_showall_bottom_hidden.css";          /**/
+    /*/ @import "./css/buttons/bookmarks_menu_button_popup_sidebar_item_hidden.css";            /**/
+    /*/ @import "./css/buttons/bookmarks_menu_button_popup_toolbar_item_hidden.css";            /**/
+    /*/ @import "./css/buttons/bookmarks_menu_button_popup_other_item_hidden.css";              /**/
 
-/* other button settings ************************************************************************/
-@import "./css/buttons/whatnew_button_always_hidden.css"; /**/
-/* @import "./css/buttons/forward_button_hide_when_disabled.css"; /**/
-/* @import "./css/buttons/back_and_forward_separated_history_popups.css"; /**/
-/* @import "./css/buttons/back_and_forward_leftclick_history_popup_hidden.css"; /**/
-/* @import "./css/buttons/zoom_buttons_hide_reset.css"; /**/
-/* @import "./css/buttons/overflow_button_rotate_on_open.css"; /**/
-
-
-/* CUSTOM BACK & FORWARD BUTTONS appearance - [only use one at a time] **************************/
-/* @import "./css/buttons/custom_backforward_large_ff2.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_ff3.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_ff3_strata.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_ff3_strata_v2.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_ff3_strata_orange.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_ff3_strata_red.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_ie8.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_ie9.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_kempelton.css"; /**/
-/* @import "./css/buttons/custom_backforward_large_noia.css"; /**/
-/* @import "./css/buttons/custom_backforward_small_ff3.css"; /**/
-/* @import "./css/buttons/custom_backforward_small_ff3_strata.css"; /**/
-/* @import "./css/buttons/custom_backforward_small_ff3_strata_orange.css"; /**/
-/* @import "./css/buttons/custom_backforward_small_ff3_strata_red.css"; /**/
-/* @import "./css/buttons/custom_backforward_small_ie8.css"; /**/
-/* @import "./css/buttons/custom_backforward_small_ie9.css"; /**/
-/* @import "./css/buttons/custom_backforward_small_kempelton.css"; /**/
-/* @import "./css/buttons/custom_backforward_connected.css"; /**/ /* round */
-/* @import "./css/buttons/custom_backforward_connected_to_location_bar.css"; /**/ /* round */
-/* @import "./css/buttons/custom_backforward_connected_alt.css"; /**/ /* squared*/
-/* @import "./css/buttons/custom_backforward_connected_to_location_bar_alt.css"; /**/ /* squared*/
+/* other button settings */
+    /*/ @import "./css/buttons/whatnew_button_always_hidden.css";                               /**/
+    /*/ @import "./css/buttons/forward_button_hide_when_disabled.css";                          /**/
+    /*/ @import "./css/buttons/back_and_forward_separated_history_popups.css";                  /**/
+    /*/ @import "./css/buttons/back_and_forward_leftclick_history_popup_hidden.css";            /**/
+    /*/ @import "./css/buttons/zoom_buttons_hide_reset.css";                                    /**/
+    /*/ @import "./css/buttons/overflow_button_rotate_on_open.css";                             /**/
 
 
-/************************************************************************************************/
-/* APPLICATION / HAMBURGER / MAIN MENU BUTTON ***************************************************/
-/************************************************************************************************/
+/* ========================================
+ * CUSTOM BACK & FORWARD BUTTONS appearance - 
+ * ========================================
+ * [only use one at a time]
+ */
+                                                                            /* ON | OFF */
+    /*/ @import "./css/buttons/custom_backforward_large_ff2.css";                   /**/
+    /*/ @import "./css/buttons/custom_backforward_large_ff3.css";                   /**/
+    /*/ @import "./css/buttons/custom_backforward_large_ff3_strata.css";            /**/
+    /*/ @import "./css/buttons/custom_backforward_large_ff3_strata_v2.css";         /**/
+    /*/ @import "./css/buttons/custom_backforward_large_ff3_strata_orange.css";     /**/
+    /*/ @import "./css/buttons/custom_backforward_large_ff3_strata_red.css";        /**/
+    /*/ @import "./css/buttons/custom_backforward_large_ie8.css";                   /**/
+    /*/ @import "./css/buttons/custom_backforward_large_ie9.css";                   /**/
+    /*/ @import "./css/buttons/custom_backforward_large_kempelton.css";             /**/
+    /*/ @import "./css/buttons/custom_backforward_large_noia.css";                  /**/
+    /*/ @import "./css/buttons/custom_backforward_small_ff3.css";                   /**/
+    /*/ @import "./css/buttons/custom_backforward_small_ff3_strata.css";            /**/
+    /*/ @import "./css/buttons/custom_backforward_small_ff3_strata_orange.css";     /**/
+    /*/ @import "./css/buttons/custom_backforward_small_ff3_strata_red.css";        /**/
+    /*/ @import "./css/buttons/custom_backforward_small_ie8.css";                   /**/
+    /*/ @import "./css/buttons/custom_backforward_small_ie9.css";                   /**/
+    /*/ @import "./css/buttons/custom_backforward_small_kempelton.css";             /**/
+    /*/ round */
+    /*/ @import "./css/buttons/custom_backforward_connected.css";                   /**/ 
+    /*/ round */
+    /*/ @import "./css/buttons/custom_backforward_connected_to_location_bar.css";   /**/ 
+    /*/ squared*/
+    /*/ @import "./css/buttons/custom_backforward_connected_alt.css";               /**/ 
+    /*/ @import "./css/buttons/custom_backforward_connected_to_location_bar_alt.css"; /**/ /* squared*/
+
+
+/* APPLICATION / HAMBURGER / MAIN MENU BUTTON
 
 /* application/hamburger button hidden - disable all other appbutton options when using this ****/
 /* @import "./css/appbutton/appbutton_hidden.css"; /**/
 
-/* application/hamburger button popup ***********************************************************/
+/* application/hamburger button popup
 @import "./css/appbutton/appbutton_popup_icons.css"; /**/
 @import "./css/appbutton/appbutton_popup_icons_colorized.css"; /**/
 /* @import "./css/appbutton/appbutton_popup_sync_hidden.css"; /**/
 /* @import "./css/appbutton/appbutton_popup_logins_and_passwords_hidden.css"; /**/
 
-/************************************************************************************************/
-/* Application / hamburger / main menu button on navigation toolbar *****************************/
-/************************************************************************************************/
+/* Application / hamburger / main menu button on navigation toolbar
 
 /* [!] disable all 'button in Firefox titlebar' options for
-       'button on navigation toolbar' options to work properly **********************************/
+ *      'button on navigation toolbar' options to work properly
+ */
 
-/* @import "./css/appbutton/appbutton_on_navbar_start_position.css"; /**/
+                                                                           /* ON | OFF */
+    /*/ @import "./css/appbutton/appbutton_on_navbar_start_position.css";          /**/
 
-/* button color - [only use one at a time] ******************************************************/
-/* @import "./css/appbutton/appbutton_on_navbar_color_autocolor.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_color_autocolor57p.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_color_orange.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_color_aurora.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_color_nightly.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_color_deved57p.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_color_nightly57p.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_color_palemoon.css"; /**/
+/* button color - [only use one at a time] */
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_autocolor.css";         /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_autocolor57p.css";      /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_orange.css";            /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_aurora.css";            /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_nightly.css";           /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_deved57p.css";          /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_nightly57p.css";        /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_color_palemoon.css";          /**/
 
-/* button icon - [only use one at a time] *******************************************************/
-/* @import "./css/appbutton/appbutton_on_navbar_icon_white.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_icon_dark.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_icon_grey.css"; /**/
-/* @import "./css/appbutton/appbutton_on_navbar_icon_browser_logo.css"; /**/
+/* button icon - [only use one at a time] */
+    /*/ @import "./css/appbutton/appbutton_on_navbar_icon_white.css";              /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_icon_dark.css";               /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_icon_grey.css";               /**/
+    /*/ @import "./css/appbutton/appbutton_on_navbar_icon_browser_logo.css";       /**/
 
-/* button label (show label besides icon) *******************************************************/
-/* @import "./css/appbutton/appbutton_on_navbar_icon_and_label.css"; /**/
+/* button label (show label besides icon)
+    /*/ @import "./css/appbutton/appbutton_on_navbar_icon_and_label.css";          /**/
 
 
-/************************************************************************************************/
-/* Application / hamburger / main menu button in Firefox titlebar *******************************/
-/************************************************************************************************/
+/* Application / hamburger / main menu button in Firefox titlebar
 
 /* [!] disable all 'button on navigation toolbar' options for
-       'button in Firefox titlebar' options to work properly ************************************/
+       'button in Firefox titlebar' options to work properly
 
-/* button in titlebar - [only use one at a time] ************************************************/
-@import "./css/appbutton/appbutton_in_titlebar.css"; /**/ /* <-- label only */
-/* @import "./css/appbutton/appbutton_in_titlebar_icon_only.css"; /**/
+                                                                           /* ON | OFF */
+/* button in titlebar - [only use one at a time]
+/* <-- label only */
+@import "./css/appbutton/appbutton_in_titlebar.css";                        /**/ 
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_icon_only.css";              /**/
+    
+    /*/ for 'appbutton in titlebar icon only' - [only use one at a time]
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_icon_only_dark.css";         /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_icon_only_grey.css";         /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_icon_only_browser_logo.css"; /**/
 
-/* for 'appbutton in titlebar icon only' - [only use one at a time] *****************************/
-/* @import "./css/appbutton/appbutton_in_titlebar_icon_only_dark.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_icon_only_grey.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_icon_only_browser_logo.css"; /**/
+/* for 'appbutton in titlebar icon only'
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_label_and_icon.css";    /**/
+    
+    /* macOS fix - appbutton in titlebar gets moved to the right */
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_macOS_fix.css";         /**/
+    
+    /*/ button color - [only use one at a time]
+@import "./css/appbutton/appbutton_in_titlebar_autocolor.css";             /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_autocolor57p.css";      /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_transparent.css";       /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_semi_transparent.css";  /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_aurora.css";            /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_nightly.css";           /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_deved57p.css";          /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_nightly57p.css";        /**/
+    /*/ @import "./css/appbutton/appbutton_in_titlebar_palemoon.css";          /**/
 
-/* for 'appbutton in titlebar icon only' ********************************************************/
-/* @import "./css/appbutton/appbutton_in_titlebar_label_and_icon.css"; /**/
+/* ==================================
+ * [2] TABS - appearance and position
+ * ==================================
+ */
 
-/* macOS fix - appbutton in titlebar gets moved to the right ************************************/
-/* @import "./css/appbutton/appbutton_in_titlebar_macOS_fix.css"; /**/
+/* Custom tab appearance - [only use one at a time] */
+                                                                      /* ON | OFF */
 
-/* button color - [only use one at a time] ******************************************************/
-@import "./css/appbutton/appbutton_in_titlebar_autocolor.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_autocolor57p.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_transparent.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_semi_transparent.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_aurora.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_nightly.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_deved57p.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_nightly57p.css"; /**/
-/* @import "./css/appbutton/appbutton_in_titlebar_palemoon.css"; /**/
+@import "./css/tabs/classic_squared_tabs.css";                                /**/
+    /*/ @import "./css/tabs/classic_squared_tabs_australized.css";            /**/
+    /*/ @import "./css/tabs/default_tabs_enhanced.css";                       /**/
+/* squared tabs like in Fx 57-88 */
+    /*/ @import "./css/tabs/default_tabs_photon.css";                         /**/ 
 
-
-/************************************************************************************************/
-/* TABS - appearance and position ***************************************************************/
-/************************************************************************************************/
-
-/* custom tab appearance - [only use one at a time] *********************************************/
-@import "./css/tabs/classic_squared_tabs.css"; /**/
-/* @import "./css/tabs/classic_squared_tabs_australized.css"; /**/
-/* @import "./css/tabs/default_tabs_enhanced.css"; /**/
-/* @import "./css/tabs/default_tabs_photon.css"; /**/ /* squared tabs like in Fx 57-88 */
-
-/* custom tab colors are set inside color_variables***.css file(s) ******************************/
+/* custom tab colors are set inside color_variables***.css file(s)
 
 
-/************************************************************************************************/
-/* TABS TOOLBAR POSITION (below titlebar / below navigation toolbar / below main content) *******/
-/************************************************************************************************/
+/* TABS TOOLBAR POSITION (below titlebar / below navigation toolbar / below main content)
 
-/* [only use one at a time] - BELOW TITLEBAR or BELOW NAVIGATION BAR or BELOW MAIN CONTENT ******/
+/* [only use one at a time] - BELOW TITLEBAR or BELOW NAVIGATION BAR or BELOW MAIN CONTENT
 
-/* - TABS BELOW TITLEBAR (Fx56-like tabs position) **********************************************/
-/* @import "./css/tabs/tabs_below_titlebar_above_navigation_toolbar.css"; /**/
+/* - TABS BELOW TITLEBAR (Fx56-like tabs position)
+    /*/ @import "./css/tabs/tabs_below_titlebar_above_navigation_toolbar.css"; /**/
 
-/* - TABS BELOW NAVIGATION AND BOOKMARKS TOOLBARS / TABS NOT ON TOP *****************************/
-/* [!] Note: only 'alt' works with multi-tab lines option. **************************************/
+/* - TABS BELOW NAVIGATION AND BOOKMARKS TOOLBARS / TABS NOT ON TOP
+/* [!] Note: only 'alt' works with multi-tab lines option.
 /* [!] Note: might require overriding url bars 'selection color' --> see corresponding area *****/
-/* - Windows/Linux ******************************************************************************/
-/* @import "./css/tabs/tabs_below_navigation_toolbar.css"; /**/
-/* - macOS **************************************************************************************/
-/* @import "./css/tabs/tabs_below_navigation_toolbar_macOS.css"; /**/
+/* - Windows/Linux
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar.css";                                                 /**/
+/* - macOS
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar_macOS.css";                                           /**/
 
-/* - Alternative for multi-lined tabs (Glitches with inactive menubar!) ******************/  /* <- use this for multiple tab lines support */
-/* @import "./css/tabs/tabs_below_navigation_toolbar_alt.css"; /**/
-/* @import "./css/tabs/tabs_below_navigation_toolbar_alt_force_hidden_menubar.css"; /**/ /* no menubar when OS titlebar is active */
-/* @import "./css/tabs/tabs_below_navigation_toolbar_alt_macOS.css"; /**/
+/* - Alternative for multi-lined tabs (Glitches with inactive menubar!) /* <- use this for multiple tab lines support */
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar_alt.css";                                             /**/
+/* no menubar when OS titlebar is active */
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar_alt_force_hidden_menubar.css";                        /**/ 
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar_alt_macOS.css";                                       /**/
 
-/* - TABS BELOW MAIN CONTENT (TABS ON BOTTOM) - *************************************************/
-/* [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/33 **********************/
-/* [!] not compatible to 'tabs toolbar - multiple tab lines' option *****************************/
-/* - Windows/Linux - ****************************************************************************/
-/* @import "./css/tabs/tabs_below_main_content.css"; /**/
-/* - macOS - ************************************************************************************/
-/* @import "./css/tabs/tabs_below_main_content_macOS.css"; /**/
+/* - TABS BELOW MAIN CONTENT (TABS ON BOTTOM) -
+/* [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/33
+/* [!] not compatible to 'tabs toolbar - multiple tab lines' option
+/* - Windows/Linux -
+    /*/ @import "./css/tabs/tabs_below_main_content.css";                                                        /**/
+/* - macOS -
+    /*/ @import "./css/tabs/tabs_below_main_content_macOS.css";                                                  /**/
 
 /* - MOVE NAVIGATION TOOLBAR TO HIGHER POSITON (for tabs not on top) - [only use one at a time] */
-/* @import "./css/tabs/tabs_below_navigation_toolbar_higher_navbar_positon.css"; /**/			/* <--- EXPERIMENTAL */
-/* @import "./css/tabs/tabs_below_navigation_toolbar_higher_navbar_positon_with_appbutton.css"; /**/  /* <--- EXPERIMENTAL */
-/* @import "./css/tabs/tabs_below_navigation_toolbar_higher_navbar_positon_with_appbutton_icon_only.css"; /**/  /* <--- EXPERIMENTAL */
+/* <--- EXPERIMENTAL */
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar_higher_navbar_positon.css";                            /**/
+/* <--- EXPERIMENTAL */
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar_higher_navbar_positon_with_appbutton.css";             /**/
+/* <--- EXPERIMENTAL */
+    /*/ @import "./css/tabs/tabs_below_navigation_toolbar_higher_navbar_positon_with_appbutton_icon_only.css";   /**/
 
 
-/* TAB BACKGROUND COLORS for default/active/hovered/unloaded tabs and 'new tab' tab *************/
-/* edit target file to set own custom colors ****************************************************/
-/* @import "./config/custom_tab_color_settings.css"; /**/
-/* TAB TEXT colors/shadow/weight/style for default/active/hovered/unloaded tabs *****************/
-/* edit target file to set own custom colors ****************************************************/
-/* @import "./config/custom_tab_text_settings.css"; /**/
+/* TAB BACKGROUND COLORS for default/active/hovered/unloaded tabs and 'new tab' tab
+/* edit target file to set own custom colors
+    /*/ @import "./config/custom_tab_color_settings.css"; /**/
+/* TAB TEXT colors/shadow/weight/style for default/active/hovered/unloaded tabs
+/* edit target file to set own custom colors
+    /*/ @import "./config/custom_tab_text_settings.css"; /**/
 
-/* MULTIROW / multi lined tabs - [only use one at a time] - EXPERIMENTAL ************************/
-/* [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/39 **********************/
-/* [!] BUG: dragging tabs does not work with multi lined tabs ***********************************/
-/* [!] not compatible with 'tabs toolbar - below main content' option ***************************/
-/* [!] only compatible with 'tabs below navigation toolbar alt version' *************************/
+/* MULTIROW / multi lined tabs - [only use one at a time] - EXPERIMENTAL
+ * [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/39
+ * [!] BUG: dragging tabs does not work with multi lined tabs
+ * [!] not compatible with 'tabs toolbar - below main content' option
+ * [!] only compatible with 'tabs below navigation toolbar alt version'
+ */
+
 /* @import "./css/tabs/tabs_multiple_lines.css"; /**/
 /* @import "./css/tabs/tabs_multiple_lines_force_newtab_button_visibility.css"; /**/
 
 
-/* restore empty/missing tab favicon - [only use one at a time] *********************************/
-@import "./css/tabs/missing_tab_favicon_restored_default.css"; /**/
-/* @import "./css/tabs/missing_tab_favicon_restored_globe_v2.css"; /**/
-/* @import "./css/tabs/missing_tab_favicon_restored_sheet.css"; /**/
-/* @import "./css/tabs/missing_tab_favicon_restored_dotted.css"; /**/
-/* @import "./css/tabs/missing_tab_favicon_restored_dotted_white.css"; /**/
-/* @import "./css/tabs/missing_tab_favicon_restored_brand_logo.css"; /**/
+/* restore empty/missing tab favicon - [only use one at a time]
+                                                                         /* ON | OFF */
 
-/* custom tab loading animation - [only use one at a time] **************************************/
-/* @import "./css/tabs/tab_throbber_blue_fx56.css"; /**/ /* known from Fx 56 */
-/* @import "./css/tabs/tab_throbber_blue.css"; /**/
-/* @import "./css/tabs/tab_throbber_grey_classic.css"; /**/
-/* @import "./css/tabs/tab_throbber_green.css"; /**/
-/* @import "./css/tabs/tab_throbber_orange_ubuntu.css"; /**/
+@import "./css/tabs/missing_tab_favicon_restored_default.css";             /**/
+    /*/ @import "./css/tabs/missing_tab_favicon_restored_globe_v2.css";           /**/
+    /*/ @import "./css/tabs/missing_tab_favicon_restored_sheet.css";              /**/
+    /*/ @import "./css/tabs/missing_tab_favicon_restored_dotted.css";             /**/
+    /*/ @import "./css/tabs/missing_tab_favicon_restored_dotted_white.css";       /**/
+    /*/ @import "./css/tabs/missing_tab_favicon_restored_brand_logo.css";         /**/
 
-/* tab close icon settings - [only use one at a time] *******************************************/
-@import "./css/tabs/tab_close_always_visible.css"; /**/
-/* @import "./css/tabs/tab_close_on_active_tab_only.css"; /**/
-/* @import "./css/tabs/tab_close_show_on_hover_only.css"; /**/
-/* @import "./css/tabs/tab_close_hidden.css"; /**/
-/* @import "./css/tabs/tab_close_hidden_for_only_one_visible_tab.css"; /**/
-/* @import "./css/tabs/tab_close_at_tabs_start.css"; /**/
-/* @import "./css/tabs/tab_close_icon_size.css"; /**/
+/* custom tab loading animation - [only use one at a time] 
+                                                                   /* ON | OFF */
+/* known from Fx 56 */
+    /*/ @import "./css/tabs/tab_throbber_blue_fx56.css";                    /**/ 
+    /*/ @import "./css/tabs/tab_throbber_blue.css";                         /**/
+    /*/ @import "./css/tabs/tab_throbber_grey_classic.css";                 /**/
+    /*/ @import "./css/tabs/tab_throbber_green.css";                        /**/
+    /*/ @import "./css/tabs/tab_throbber_orange_ubuntu.css";                /**/
 
-/* tab title - [only use one at a time] *********************************************************/
-/* @import "./css/tabs/tab_title_left.css"; /**/
-/* @import "./css/tabs/tab_title_centered.css"; /**/
-/* @import "./css/tabs/tab_title_right.css"; /**/
+/* tab close icon settings - [only use one at a time]
+@import "./css/tabs/tab_close_always_visible.css";                          /**/
+    /*/ @import "./css/tabs/tab_close_on_active_tab_only.css";              /**/
+    /*/ @import "./css/tabs/tab_close_show_on_hover_only.css";              /**/
+    /*/ @import "./css/tabs/tab_close_hidden.css";                          /**/
+    /*/ @import "./css/tabs/tab_close_hidden_for_only_one_visible_tab.css"; /**/
+    /*/ @import "./css/tabs/tab_close_at_tabs_start.css";                   /**/
+    /*/ @import "./css/tabs/tab_close_icon_size.css";                       /**/
 
-/* DEFAULT TABS - use only, if 'classic squared tabs' are disabled ******************************/
-/* tab line settings - [only use one at a time] *************************************************/
-/* @import "./css/tabs/default_tabs_no_tab_line.css"; /**/
-/* @import "./css/tabs/default_tabs_tab_line_red_for_unloaded_tabs.css"; /**/
-/* @import "./css/tabs/default_tabs_tab_line_purple_in_private_mode.css"; /**/
+/* tab title - [only use one at a time]
+    /*/ @import "./css/tabs/tab_title_left.css";                            /**/
+    /*/ @import "./css/tabs/tab_title_centered.css";                        /**/
+    /*/ @import "./css/tabs/tab_title_right.css";                           /**/
 
+/* DEFAULT TABS - use only, if 'classic squared tabs' are disabled
+ *
+ * tab line settings - [only use one at a time]
+ */
 
-/* other tab settings ***************************************************************************/
+    /* @import "./css/tabs/default_tabs_no_tab_line.css";                     /**/
+    /* @import "./css/tabs/default_tabs_tab_line_red_for_unloaded_tabs.css";  /**/
+    /* @import "./css/tabs/default_tabs_tab_line_purple_in_private_mode.css"; /**/
+
+/* ------------------
+ * Other tab settings
+ * ------------------
+ */
+
+                                                                               /* ON | OFF */
 @import "./css/tabs/tab_icon_colors.css"; /**/
-/* @import "./css/tabs/default_tabs_reduce_spaces.css"; /**/
-/* @import "./css/tabs/tabs_fully_squared.css"; /**/
-/* @import "./css/tabs/tab_audio_icon.css"; /**/
-/* @import "./css/tabs/tab_audio_icon_colorized.css"; /**/
-/* @import "./css/tabs/tabs_container_indicator_for_classic_squared_tabs.css"; /**/
-/* @import "./css/tabs/tabs_active_tab_indicator_for_classic_squared_tabs.css"; /**/
-/* @import "./css/tabs/newtab_tab_size_equals_tab_size.css"; /**/
-/* @import "./css/tabs/newtab_button_always_visible.css"; /**/
-/* @import "./css/tabs/tab_icon_inactive_tabs_lower_opacity.css"; /**/
-/* @import "./css/tabs/tab_icon_unloaded_tabs_lower_opacity.css"; /**/
-/* @import "./css/tabs/tab_maxwidth.css"; /**/
-/* @import "./css/tabs/tab_titles_remove_blur.css"; /**/
-/* @import "./css/tabs/alltabs_button_always_visible.css"; /**/  /* <--- hidden, if multiple tab rows are used */
-/* @import "./css/tabs/pinnedtab_empty_favicon_hidden.css"; /**/
-/* [!] edit target file to select which items to hide *******************************************/
-/* @import "./css/tabs/tab_context_menuitems_visibility.css"; /**/
+    /*/ @import "./css/tabs/default_tabs_reduce_spaces.css";                           /**/
+    /*/ @import "./css/tabs/tabs_fully_squared.css";                                   /**/
+    /*/ @import "./css/tabs/tab_audio_icon.css";                                       /**/
+    /*/ @import "./css/tabs/tab_audio_icon_colorized.css";                             /**/
+    /*/ @import "./css/tabs/tabs_container_indicator_for_classic_squared_tabs.css";    /**/
+    /*/ @import "./css/tabs/tabs_active_tab_indicator_for_classic_squared_tabs.css";   /**/
+    /*/ @import "./css/tabs/newtab_tab_size_equals_tab_size.css";                      /**/
+    /*/ @import "./css/tabs/newtab_button_always_visible.css";                         /**/
+    /*/ @import "./css/tabs/tab_icon_inactive_tabs_lower_opacity.css";                 /**/
+    /*/ @import "./css/tabs/tab_icon_unloaded_tabs_lower_opacity.css";                 /**/
+    /*/ @import "./css/tabs/tab_maxwidth.css";                                         /**/
+    /*/ @import "./css/tabs/tab_titles_remove_blur.css";                               /**/
+/* <--- hidden, if multiple tab rows are used */
+    /*/ @import "./css/tabs/alltabs_button_always_visible.css";                        /**/  
+    /*/ @import "./css/tabs/pinnedtab_empty_favicon_hidden.css";                       /**/
+    /*/ [!] edit target file to select which items to hide 
+    /*/ @import "./css/tabs/tab_context_menuitems_visibility.css";                     /**/
 
 
-/************************************************************************************************/
-/* GENERAL UI ***********************************************************************************/
-/************************************************************************************************/
+/* ==============
+ * [3] GENERAL UI
+ * ==============
+ */
+                                                                               /* ON | OFF */
 
-@import "./css/generalui/private_mode_indicator_hidden.css"; /**/
-@import "./css/generalui/bookmark_icons_colorized.css"; /**/
-/* @import "./css/generalui/bookmarks_smaller_more_bookmarks_icon.css"; /**/
-/* @import "./css/generalui/send_to_device_menuitems_hidden.css"; /**/
-/* @import "./css/generalui/set_as_desktop_background_menuitems_hidden.css"; /**/
-/* @import "./css/generalui/increase_ui_font_size.css"; /**/
-/* @import "./css/generalui/flex_space_on_navbar_replace_with_separator.css"; /**/
-/* @import "./css/generalui/statusbar_color.css"; /**/
-/* @import "./css/generalui/classic_drop_indicator.css"; /**/
-/* @import "./css/generalui/notification_old_size.css"; /**/
+@import "./css/generalui/private_mode_indicator_hidden.css";                   /**/
+@import "./css/generalui/bookmark_icons_colorized.css";                        /**/
+    /*/ @import "./css/generalui/bookmarks_smaller_more_bookmarks_icon.css";           /**/
+    /*/ @import "./css/generalui/send_to_device_menuitems_hidden.css";                 /**/
+    /*/ @import "./css/generalui/set_as_desktop_background_menuitems_hidden.css";      /**/
+    /*/ @import "./css/generalui/increase_ui_font_size.css";                           /**/
+    /*/ @import "./css/generalui/flex_space_on_navbar_replace_with_separator.css";     /**/
+    /*/ @import "./css/generalui/statusbar_color.css";                                 /**/
+    /*/ @import "./css/generalui/classic_drop_indicator.css";                          /**/
+    /*/ @import "./css/generalui/notification_old_size.css";                           /**/
 
-/* overflow menu - [only use one at a time] *****************************************************/
+/* overflow menu - [only use one at a time]
 /* @import "./css/generalui/overflow_menu_remove_text.css"; /**/
 /* @import "./css/generalui/overflow_menu_horizontal_remove_text.css"; /**/
 
-/* context menu / menupopup / panel appearance (not for macOS) **********************************/
-/* [!] affects context menus, popup menus and panel menus on Windows 10 *************************/
-/* [!] affects panel menus on Windows 7 and 8 and on Linux **************************************/
-/* @import "./css/generalui/popup_compact_menus.css"; /**/
-/* @import "./css/generalui/popup_compact_menus_squared.css"; /**/
-/* @import "./css/generalui/popup_menus_space_before_label.css"; /**/
-/* @import "./css/generalui/popup_menus_menu_background.css"; /**/
+/* context menu / menupopup / panel appearance (not for macOS)
+/* [!] affects context menus, popup menus and panel menus on Windows 10
+/* [!] affects panel menus on Windows 7 and 8 and on Linux
 
-/* other context menu settings ******************************************************************/
-/* @import "./css/generalui/popup_items_hover_appearance_aero.css"; /**/
-/* @import "./css/generalui/popup_animation_fade_time_reduced.css"; /**/
-/* @import "./css/generalui/popup_menupopup_with_scrollbars.css"; /**/  /* <- this removes tab scroll buttons, no CSS fix possible atm */
+    /*/ @import "./css/generalui/popup_compact_menus.css";                     /**/
+    /*/ @import "./css/generalui/popup_compact_menus_squared.css";             /**/
+    /*/ @import "./css/generalui/popup_menus_space_before_label.css";          /**/
+    /*/ @import "./css/generalui/popup_menus_menu_background.css";             /**/
 
-/* page context menu items: 'back', 'forward', 'reload', 'stop', 'bookmarks' ********************/
-/* @import "./css/generalui/context_bfrsb_icons_colorized.css"; /**/
-/* menuitem labels - [only use one at a time] ***************************************************/
-@import "./css/generalui/context_bfrsb_labels_without_icons.css"; /**/
-/* @import "./css/generalui/context_bfrsb_labels_with_icons.css"; /**/
+/* other context menu settings
+    /*/ @import "./css/generalui/popup_items_hover_appearance_aero.css";       /**/
+    /*/ @import "./css/generalui/popup_animation_fade_time_reduced.css";       /**/
+/* <- this removes tab scroll buttons, no CSS fix possible atm */
+    /*/ @import "./css/generalui/popup_menupopup_with_scrollbars.css";         /**/
 
-/* sidebar **************************************************************************************/
-/* @import "./css/generalui/sidebar_items_compact.css"; /**/
-/* @import "./css/generalui/sidebar_header_icons.css"; /**/ /* adds icons to the popup */
-/* @import "./css/generalui/sidebar_header_icons_colorized.css"; /**/
-/* @import "./css/generalui/sidebar_header_lwtheme.css"; /**/
-/* sidebar dimensions - [only use one at a time] ************************************************/
-/* @import "./css/generalui/sidebar_show_on_hover.css"; /**/
-/* @import "./css/generalui/sidebar_width_unrestricted.css"; /**/
-/* sidebar appearance - [only use one at a time] ************************************************/
-/* @import "./css/generalui/sidebar_appearance_grey.css"; /**/
-/* @import "./css/generalui/sidebar_appearance_grey_v2.css"; /**/
-/* @import "./css/generalui/sidebar_appearance_dark.css"; /**/
-/* @import "./css/generalui/sidebar_appearance_dark_v2.css"; /**/
-/* @import "./css/generalui/sidebar_appearance_lwtheme_bright.css"; /**/
-/* @import "./css/generalui/sidebar_appearance_lwtheme_dark.css"; /**/
+/* page context menu items: 'back', 'forward', 'reload', 'stop', 'bookmarks'
+/* @import "./css/generalui/context_bfrsb_icons_colorized.css";                /**/
+/* menuitem labels - [only use one at a time]
+@import "./css/generalui/context_bfrsb_labels_without_icons.css";              /**/
+/* @import "./css/generalui/context_bfrsb_labels_with_icons.css";              /**/
 
+/* sidebar
+                                                                       /* ON | OFF */
 
-/* FINDBAR **************************************************************************************/
-/* @import "./css/generalui/findbar_on_top.css"; /**/
-/* @import "./css/generalui/findbar_close_at_findbars_start.css"; /**/
-/* @import "./css/generalui/findbar_compact.css"; /**/
+    /*/ @import "./css/generalui/sidebar_items_compact.css";                   /**/
+/* adds icons to the popup */
+    /*/ @import "./css/generalui/sidebar_header_icons.css";                    /**/ 
+    /*/ @import "./css/generalui/sidebar_header_icons_colorized.css";          /**/
+    /*/ @import "./css/generalui/sidebar_header_lwtheme.css";                  /**/
+    /*/ sidebar dimensions - [only use one at a time]
+    /*/ @import "./css/generalui/sidebar_show_on_hover.css";                   /**/
+    /*/ @import "./css/generalui/sidebar_width_unrestricted.css";              /**/
+    /*/ sidebar appearance - [only use one at a time]
+    /*/ @import "./css/generalui/sidebar_appearance_grey.css";                 /**/
+    /*/ @import "./css/generalui/sidebar_appearance_grey_v2.css";              /**/
+    /*/ @import "./css/generalui/sidebar_appearance_dark.css";                 /**/
+    /*/ @import "./css/generalui/sidebar_appearance_dark_v2.css";              /**/
+    /*/ @import "./css/generalui/sidebar_appearance_lwtheme_bright.css";       /**/
+    /*/ @import "./css/generalui/sidebar_appearance_lwtheme_dark.css";         /**/
 
-/* close icons for general ui and tabs - [only use one at a time] *******************************/
-/* @import "./css/generalui/close_icon_windows7.css"; /**/
-/* @import "./css/generalui/close_icon_windows7inverted.css"; /**/
-/* @import "./css/generalui/close_icon_windows7v2.css"; /**/
-/* @import "./css/generalui/close_icon_gchrome.css"; /**/
-/* @import "./css/generalui/close_icon_red.css"; /**/
-/* @import "./css/generalui/close_icon_windows10.css"; /**/
-/* @import "./css/generalui/close_icon_windows10inverted.css"; /**/
-/* @import "./css/generalui/close_icon_windows10red.css"; /**/
-/* @import "./css/generalui/close_icon_windows10redv2.css"; /**/
-/* @import "./css/generalui/close_icon_firefox3.css"; /**/
+/* =======
+ * FINDBAR
+ * =======
+ */
+                                                                        /* ON | OFF */
 
-/* SEARCHBAR ************************************************************************************/
-@import "./css/generalui/searchbar_glassplus_indicator_hidden.css"; /**/
-/* @import "./css/generalui/searchbar_go_button_hidden.css"; /**/
+    /* @import "./css/generalui/findbar_on_top.css";                           /**/
+    /* @import "./css/generalui/findbar_close_at_findbars_start.css";          /**/
+    /* @import "./css/generalui/findbar_compact.css";                          /**/
 
-/* searchbar popup ******************************************************************************/
-/* @import "./css/generalui/searchbar_popup_current_engine_hidden.css"; /**/
-/* searchbar popup - search engine settings - [only use one at a time] **************************/
-/* @import "./css/generalui/searchbar_popup_engines_hidden.css"; /**/
-/* @import "./css/generalui/searchbar_popup_engines_show_labels.css"; /**/
-/* @import "./css/generalui/searchbar_popup_engines_show_labels_scrollbars.css"; /**/
+/* -- close icons for general ui and tabs - [only use one at a time]
 
-/* MENUBARS bookmarks popup (not compatible to macOS/Linux) *************************************/
-/* @import "./css/generalui/menubar_bookmarks_popup_bookmark_page_item_hidden.css"; /**/
-/* @import "./css/generalui/menubar_bookmarks_popup_subscribe_item_hidden.css"; /**/
-/* @import "./css/generalui/menubar_bookmarks_popup_toolbar_item_hidden.css"; /**/
-/* @import "./css/generalui/menubar_bookmarks_popup_other_item_hidden.css"; /**/
+    /*/ @import "./css/generalui/close_icon_windows7.css";                     /**/
+    /*/ @import "./css/generalui/close_icon_windows7inverted.css";             /**/
+    /*/ @import "./css/generalui/close_icon_windows7v2.css";                   /**/
+    /*/ @import "./css/generalui/close_icon_gchrome.css";                      /**/
+    /*/ @import "./css/generalui/close_icon_red.css";                          /**/
+    /*/ @import "./css/generalui/close_icon_windows10.css";                    /**/
+    /*/ @import "./css/generalui/close_icon_windows10inverted.css";            /**/
+    /*/ @import "./css/generalui/close_icon_windows10red.css";                 /**/
+    /*/ @import "./css/generalui/close_icon_windows10redv2.css";               /**/
+    /*/ @import "./css/generalui/close_icon_firefox3.css";                     /**/
 
 
-/************************************************************************************************/
-/* TOOLBARS *************************************************************************************/
-/************************************************************************************************/
+/* --------- 
+ * SEARCHBAR
+ * ---------
+ */
+                                                                                  / ON | OFF /
 
-/* ADDON BAR - simulate add-on bar by moving bookmarks toolbar to the bottom ********************/
-/* [!] move 'Bookmarks Toolbar Items' to navigation bar to get a top toolbar with bookmarks *****/
-/* [!] not compatible to 'bookmarks toolbar - multiple lines' option ****************************/
-/* [!] not compatible to 'bookmarks toolbar autohide' option ************************************/
-/* [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/73 **********************/
-/* @import "./css/toolbars/addonbar_move_bookmarks_toolbar_to_bottom.css"; /**/  /* <--- EXPERIMENTAL */
-/* @import "./css/toolbars/addonbar_move_bookmarks_toolbar_to_bottom_tabs_on_bottom_compatibility.css"; /**/  /* <--- EXPERIMENTAL */
-/* @import "./css/toolbars/addonbar_content_on_the_right.css"; /**/  /* <--- EXPERIMENTAL */
-/* @import "./css/toolbars/addonbar_status_in_addonbar.css"; /**/  /* <--- EXPERIMENTAL */
-/* @import "./css/toolbars/addonbar_fullscreen_autohide.css"; /**/  /* <--- EXPERIMENTAL */
-/* [!] create additional toolbar for 'bookmarks toolbar items' on navigation toolbar ************/
-/* @import "./css/toolbars/addonbar_extra_bookmarks_toolbar_below_navbar.css"; /**/  /* <--- EXPERIMENTAL */
+@import "./css/generalui/searchbar_glassplus_indicator_hidden.css";                      /**/
+    /*/ @import "./css/generalui/searchbar_go_button_hidden.css";                        /**/
+    
+    /*/ searchbar popup 
+    /*/ @import "./css/generalui/searchbar_popup_current_engine_hidden.css";             /**/
+    /*/ searchbar popup - search engine settings - [only use one at a time] 
+    /*/ @import "./css/generalui/searchbar_popup_engines_hidden.css";                    /**/
+    /*/ @import "./css/generalui/searchbar_popup_engines_show_labels.css";               /**/
+    /*/ @import "./css/generalui/searchbar_popup_engines_show_labels_scrollbars.css";    /**/
+    
+    /*/ MENUBARS bookmarks popup (not compatible to macOS/Linux) 
+    /*/ @import "./css/generalui/menubar_bookmarks_popup_bookmark_page_item_hidden.css"; /**/
+    /*/ @import "./css/generalui/menubar_bookmarks_popup_subscribe_item_hidden.css";     /**/
+    /*/ @import "./css/generalui/menubar_bookmarks_popup_toolbar_item_hidden.css";       /**/
+    /*/ @import "./css/generalui/menubar_bookmarks_popup_other_item_hidden.css";         /**/
 
-/* GENERAL TOOLBAR SETTINGS *********************************************************************/
+/* ============
+ * TOOLBARS [5] 
+ * ============
+ */
 
-/* top toolbar colors - [only use one at a time] ************************************************/
-/* @import "./css/toolbars/top_toolbar_OS_accent_colors.css"; /**/ /* restore window accent color managed by the OS */
-/* @import "./css/toolbars/top_toolbar_colors.css"; /**/ /* override tabs toolbar / titlebar colors forced by Proton UI */
+/* ADDON BAR - simulate add-on bar by moving bookmarks toolbar to the bottom
+ * [!] move 'Bookmarks Toolbar Items' to navigation bar to get a top toolbar with bookmarks
+ * [!] not compatible to 'bookmarks toolbar - multiple lines' option
+ * [!] not compatible to 'bookmarks toolbar autohide' option
+ * [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/73
+ */
 
-/* other toolbar settings ***********************************************************************/
-@import "./css/toolbars/toolbars_old_padding.css"; /**/
-@import "./css/toolbars/tabs_toolbar_adjustments.css"; /**/
-/* @import "./css/toolbars/tabs_toolbar_remove_background_fog_win7.css"; /**/
-/* @import "./css/toolbars/tabs_toolbar_adjustments_macOS_fix.css"; /**/					/*  <-- macOS fix */
-@import "./css/toolbars/searchbar_on_menubar_fix.css"; /**/		/* placing searchbar on menubar requires adjustments */
+/* V--- EXPERIMENTAL ---V */
+                                                                                                     /* ON | OFF */
+    /* @import "./css/toolbars/addonbar_move_bookmarks_toolbar_to_bottom.css";                              /**/
+    /* @import "./css/toolbars/addonbar_move_bookmarks_toolbar_to_bottom_tabs_on_bottom_compatibility.css"; /**/  
+    /* @import "./css/toolbars/addonbar_content_on_the_right.css";                                          /**/
+    /* @import "./css/toolbars/addonbar_status_in_addonbar.css";                                            /**/
+    /* @import "./css/toolbars/addonbar_fullscreen_autohide.css";                                           /**/
+    /* [!] create additional toolbar for 'bookmarks toolbar items' on navigation toolbar
+    /* @import "./css/toolbars/addonbar_extra_bookmarks_toolbar_below_navbar.css";                          /**/
+/* ^--- EXPERIMENTAL ---^ */
 
-/* edit target file to select which items to hide ***********************************************/
+/* ------------------------
+ * GENERAL TOOLBAR SETTINGS
+ * ------------------------
+ */
+
+/* top toolbar colors - [only use one at a time] */
+/* restore window accent color managed by the OS */
+    /* @import "./css/toolbars/top_toolbar_OS_accent_colors.css"; /**/ 
+/* override tabs toolbar / titlebar colors forced by Proton UI */
+    /* @import "./css/toolbars/top_toolbar_colors.css"; /**/ 
+
+/* ----------------------
+ * Other toolbar settings 
+ * ----------------------
+ */
+
+                                                                                 /* ON | OFF */
+@import "./css/toolbars/toolbars_old_padding.css";                                 /**/
+@import "./css/toolbars/tabs_toolbar_adjustments.css";                             /**/
+    /*/ @import "./css/toolbars/tabs_toolbar_remove_background_fog_win7.css";            /**/
+/*  <-- macOS fix */
+    /*/ @import "./css/toolbars/tabs_toolbar_adjustments_macOS_fix.css";                 /**/
+/* placing searchbar on menubar requires adjustments */
+@import "./css/toolbars/searchbar_on_menubar_fix.css";                             /**/
+
+/* edit target file to select which items to hide
 /* @import "./css/toolbars/toolbar_context_menuitems_visibility.css"; /**/
 
-/* MENUBAR **************************************************************************************/
-/* @import "./css/toolbars/menubar_fog_hidden.css"; /**/
-/* @import "./css/toolbars/menubar_alternative_menu_hover_color.css"; /**/
-/* @import "./css/toolbars/menubar_in_fullscreen_mode.css"; /**/
-/* @import "./css/toolbars/menubar_in_fullscreen_mode_alt.css"; /**/ /*'tabs not on top alt' */
-/* menubar color - ******************************************************************************/
-/* @import "./css/toolbars/menubar_color.css"; /**/
+/* ========
+ * MENUBAR
+ * ========
+ */
+                                                                            /* ON | OFF */
 
-/* BOOKMARKS TOOLBAR ****************************************************************************/
-@import "./css/toolbars/bookmarks_toolbar_old_height.css"; /**/
-/* @import "./css/toolbars/bookmarks_toolbar_fixed_width.css"; /**/
-/* @import "./css/toolbars/bookmarks_toolbar_autohide.css"; /**/
-/* @import "./css/toolbars/bookmarks_toolbar_bookmark_labels_hidden.css"; /**/
-/* @import "./css/toolbars/bookmarks_toolbar_in_fullscreen_mode.css"; /**/
-/* [!] simulate second bookmarks toolbar while "Bookmarks Toolbar Items" element is on nav-bar **/
-/* @import "./css/toolbars/bookmarks_toolbar_simulate_second_bm_toolbar.css"; /**/
+    /*/ @import "./css/toolbars/menubar_fog_hidden.css";                            /**/
+    /*/ @import "./css/toolbars/menubar_alternative_menu_hover_color.css";          /**/
+    /*/ @import "./css/toolbars/menubar_in_fullscreen_mode.css";                    /**/
+ /*'tabs not on top alt' */
+    /*/ @import "./css/toolbars/menubar_in_fullscreen_mode_alt.css";                /**/
 
-/* BOOKMARKS TOOLBAR above navigation toolbar - [only use one at a time] ************************/
+/* menubar color
+    /*/ @import "./css/toolbars/menubar_color.css";                                 /**/
+
+/* =================
+ * BOOKMARKS TOOLBAR
+ * =================
+ */
+                                                                            /* ON | OFF */
+
+    /*/ @import "./css/toolbars/bookmarks_toolbar_old_height.css";                  /**/
+    /*/ @import "./css/toolbars/bookmarks_toolbar_fixed_width.css";                 /**/
+    /*/ @import "./css/toolbars/bookmarks_toolbar_autohide.css";                    /**/
+    /*/ @import "./css/toolbars/bookmarks_toolbar_bookmark_labels_hidden.css";      /**/
+    /*/ @import "./css/toolbars/bookmarks_toolbar_in_fullscreen_mode.css";          /**/
+    /*/ [!] simulate second bookmarks toolbar while "Bookmarks Toolbar Items" element is on nav-bar */
+    /*/ @import "./css/toolbars/bookmarks_toolbar_simulate_second_bm_toolbar.css";  /**/
+
+/* ------------------------
+ * Above navigation toolbar 
+ * ------------------------
+ * [only use one at a time]
+ */
+
 /* @import "./css/toolbars/bookmarks_toolbar_above_navigation_toolbar.css"; /**/
 /* @import "./css/toolbars/bookmarks_toolbar_above_navigation_toolbar_when_tab_not_top.css"; /**/
 
-/* BOOKMARKS TOOLBAR - MULTIPLE LINES - [only use one at a time] ********************************/
-/* [!] the amount of visible bookmark items is limited internally to ~90-110 bookmarks **********/
-/* [!] not compatible to 'bookmarks toolbar autohide' option ************************************/
-/* [!] not compatible to 'simulated second bookmarks toolbar' option ****************************/
-/* [!] not compatible to 'simulated addon-bar' option *******************************************/
-/* [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/99 **********************/
-/* @import "./css/toolbars/bookmarks_toolbar_multiple_lines.css"; /**/ /* <--- EXPERIMENTAL */
+/* =====================
+ * BOOKMARKS TOOLBAR - MULTIPLE LINES - [only use one at a time]
+ * =====================
+ */
 
-/* TOOLBAR COLORS *******************************************************************************/
-@import "./css/toolbars/general_toolbar_colors.css"; /**/
-/* @import "./css/toolbars/tab_toolbar_colors_force_menubar_color.css"; /**/
+/* [!] the amount of visible bookmark items is limited internally to ~90-110 bookmarks
+ * [!] not compatible to 'bookmarks toolbar autohide' option
+ * [!] not compatible to 'simulated second bookmarks toolbar' option
+ * [!] not compatible to 'simulated addon-bar' option
+ * [!] SUPPORT THREAD: https://github.com/aris-t2/customcssforfx/issues/99
+ */
 
-/* AeroGlass TOOLBARS - separated - set per toolbar / WIN10 fix for GLASS8 **********************/
-/* @import "./css/toolbars/general_toolbar_colors_navigation_toolbar_aeroglass.css"; /**/
-/* @import "./css/toolbars/general_toolbar_colors_bookmarks_toolbar_aeroglass.css"; /**/
-/* @import "./css/toolbars/general_toolbar_colors_tabs_toolbar_aeroglass.css"; /**/
+/* <--- EXPERIMENTAL */
+    /*/ @import "./css/toolbars/bookmarks_toolbar_multiple_lines.css"; /**/ 
+
+
+/* ==============
+ * TOOLBAR COLORS
+ * ==============
+ */
+                                                                                       /* ON | OFF */
+
+@import "./css/toolbars/general_toolbar_colors.css";                                   /**/
+    /*/ @import "./css/toolbars/tab_toolbar_colors_force_menubar_color.css";                   /**/
+
+/* AeroGlass TOOLBARS - separated - set per toolbar / WIN10 fix for GLASS8
+    /*/ @import "./css/toolbars/general_toolbar_colors_navigation_toolbar_aeroglass.css";      /**/
+    /*/ @import "./css/toolbars/general_toolbar_colors_bookmarks_toolbar_aeroglass.css";       /**/
+    /*/ @import "./css/toolbars/general_toolbar_colors_tabs_toolbar_aeroglass.css";            /**/
 /* Windows 10 fix for Glass8 - Glass8 required for 'Windows 7'-like window transparency */
-/* @import "./css/toolbars/general_toolbar_colors_aeroglass_windows10_glass8.css"; /**/  /* <--- EXPERIMENTAL */
-
-/* TOOLBAR TEXT MODES - [only use one at a time] ************************************************/
-/* @import "./css/toolbars/toolbar_mode_icons_and_text.css"; /**/
-/* @import "./css/toolbars/toolbar_mode_icons_and_text_macOS.css"; /**/ /* -> also offers alternative appearance on Linux */
-/* @import "./css/toolbars/toolbar_mode_text.css"; /**/
-/* @import "./css/toolbars/toolbar_mode_text_macOS.css"; /**/ /* -> also offers alternative appearance on Linux */
+/* <--- EXPERIMENTAL */
+    /*/ @import "./css/toolbars/general_toolbar_colors_aeroglass_windows10_glass8.css";        /**/
 
 
-/************************************************************************************************/
-/* LOCATION BAR / MEGABAR - Settings for both 'about:config > browser.urlbar.update1' cases *****/
-/************************************************************************************************/
+/* ==================
+ * TOOLBAR TEXT MODES 
+ * ==================
+ * [only use one at a time]
+ */
+                                                                    /* ON | OFF */
+
+    /*/ @import "./css/toolbars/toolbar_mode_icons_and_text.css";           /**/
+/* -> also offers alternative appearance on Linux */
+    /*/ @import "./css/toolbars/toolbar_mode_icons_and_text_macOS.css";     /**/ 
+    /*/ @import "./css/toolbars/toolbar_mode_text.css";                     /**/
+
+/* -> also offers alternative appearance on Linux */
+    /*/ @import "./css/toolbars/toolbar_mode_text_macOS.css";               /**/ 
+
+
+/*
+ * LOCATION BAR / MEGABAR - Settings for both 'about:config > browser.urlbar.update1' cases *****/
+ */
 
 /* remove color formatting of the url: about:config > browser.urlbar.formatting.enabled > false */
 
 /* @import "./css/locationbar/compact_mode_reduce_fontsize.css"; /**/
 
-/* identity box / page identity button **********************************************************/
-/* @import "./css/locationbar/identitybox_colors.css"; /**/
-/* @import "./css/locationbar/identitybox_labels_hidden.css"; /**/
-/* @import "./css/locationbar/identitybox_replace_search_icon_with_globe.css"; /**/
+/*
+ * Identity box page identity button
+ */
+                                                                           /* ON | OFF */
 
-/* padlock icons in identity box / page identity button - [only use one at a time] **************/
-/* @import "./css/locationbar/identitybox_padlock_icon_classic.css"; /**/
-/* @import "./css/locationbar/identitybox_padlock_icon_classic2.css"; /**/
-/* @import "./css/locationbar/identitybox_padlock_icon_modern.css"; /**/
-/* @import "./css/locationbar/identitybox_padlock_icon_modern2.css"; /**/
-/* @import "./css/locationbar/identitybox_padlock_icon_hidden.css"; /**/
+    /*/ @import "./css/locationbar/identitybox_colors.css";                         /**/
+    /*/ @import "./css/locationbar/identitybox_labels_hidden.css";                  /**/
+    /*/ @import "./css/locationbar/identitybox_replace_search_icon_with_globe.css"; /**/
 
-/* additional icons/buttons and tweaks for third party page action buttons **********************/
-/* @import "./css/locationbar/icons_colorized.css"; /**/
-/* @import "./css/locationbar/reader_alternative_icon.css"; /**/
-/* @import "./css/locationbar/popup_blocked_button_hidden.css"; /**/
-/* @import "./css/locationbar/zoom_button_hidden.css"; /**/
-/* @import "./css/locationbar/go_button_in_location_bar_hidden.css"; /**/
-/* @import "./css/locationbar/tracking_protection_alternative_icon.css"; /**/
+/* Padlock icons in identity box / page identity button - [only use one at a time]
+    /*/ @import "./css/locationbar/identitybox_padlock_icon_classic.css";           /**/
+    /*/ @import "./css/locationbar/identitybox_padlock_icon_classic2.css";          /**/
+    /*/ @import "./css/locationbar/identitybox_padlock_icon_modern.css";            /**/
+    /*/ @import "./css/locationbar/identitybox_padlock_icon_modern2.css";           /**/
+    /*/ @import "./css/locationbar/identitybox_padlock_icon_hidden.css";            /**/
 
-/* star button / bookmarks star *****************************************************************/
-/* @import "./css/locationbar/starbutton_popup_preview_image_hidden.css"; /**/
-/* alternative yellow star icon - [only use one at a time] **************************************/
-/* @import "./css/locationbar/starbutton_alternative_icon.css"; /**/
-/* @import "./css/locationbar/starbutton_alternative_icon_v2.css"; /**/
+/*
+ * Additional icons buttons and tweaks for third party page action buttons
+ */
 
-/* general popup/results settings ***************************************************************/
-@import "./css/locationbar/ac_popup_result_font_size.css"; /**/
-/* @import "./css/locationbar/ac_popup_firefox_background_logo.css"; /**/
+    /*/ @import "./css/locationbar/icons_colorized.css";                            /**/
+    /*/ @import "./css/locationbar/reader_alternative_icon.css";                    /**/
+    /*/ @import "./css/locationbar/popup_blocked_button_hidden.css";                /**/
+    /*/ @import "./css/locationbar/zoom_button_hidden.css";                         /**/
+    /*/ @import "./css/locationbar/go_button_in_location_bar_hidden.css";           /**/
+    /*/ @import "./css/locationbar/tracking_protection_alternative_icon.css";       /**/
+    
 
-/* selection color / force selection color on themes without predefined selection color *********/
-/* @import "./css/locationbar/selection_color_for_dark_bg.css"; /**/
-/* @import "./css/locationbar/selection_color_for_bright_bg.css"; /**/
+/* --------------------------
+ * star button bookmarks star
+ * --------------------------
+ */
+
+    /*/ @import "./css/locationbar/starbutton_popup_preview_image_hidden.css";      /**/
+    /*/ alternative yellow star icon - [only use one at a time]
+    /*/ @import "./css/locationbar/starbutton_alternative_icon.css";                /**/
+    /*/ @import "./css/locationbar/starbutton_alternative_icon_v2.css";             /**/
+
+/*
+ * General popup results settings
+ */
+                                                                         /* ON | OFF */
+
+@import "./css/locationbar/ac_popup_result_font_size.css";                 /**/
+    /*/ @import "./css/locationbar/ac_popup_firefox_background_logo.css";          /**/
+
+/* selection color / force selection color on themes without predefined selection color
+    /*/ @import "./css/locationbar/selection_color_for_dark_bg.css";               /**/
+    /*/ @import "./css/locationbar/selection_color_for_bright_bg.css";             /**/
+
+/*
+ * MEGABAR - settings for 'megabar' & 'megabar popup' 
+ */
+
+@import "./css/locationbar/megabar_expanding_breakout_disabled.css";       /**/
+    /*/ @import "./css/locationbar/megabar_disable_openviewonfocus.css";           /**/
+    /* @import "./css/locationbar/urlbar_border_roundness.css";                    /**/
+@import "./css/locationbar/urlbar_restore_visible_border.css";             /**/
+
+/*
+ * Megabar location bar background color [only use one at a time]
+ */
+
+/* Default white background color */
+    /* @import "./css/locationbar/urlbar_background_color.css";                    /**/
+
+/* Force dark color for e.g. dark lw-themes */
+    /* @import "./css/locationbar/urlbar_background_color_dark.css";               /**/
+
+/*
+ * Popup content order appearance [only use one at a time]
+ */
+                                                                                  /* ON | OFF */
+
+@import "./css/locationbar/ac_popup_megabar_title_and_url_50percent_width.css";   /**/
+    /*/ @import "./css/locationbar/ac_popup_megabar_url_and_title_50percent_width.css";   /**/
+    /*/ @import "./css/locationbar/ac_popup_megabar_title_and_url_two_lines.css";         /**/
+    /*/ @import "./css/locationbar/ac_popup_megabar_url_only.css";                        /**/
 
 
-/************************************************************************************************/
-/* MEGABAR - settings for 'megabar' & 'megabar popup' *******************************************/
-/************************************************************************************************/
+/* -----------------------------------
+ * Result menuitem settings/appearance
+ * -----------------------------------
+ */
+                                                                                    /* ON | OFF */
 
-@import "./css/locationbar/megabar_expanding_breakout_disabled.css"; /**/
-/* @import "./css/locationbar/megabar_disable_openviewonfocus.css"; /**/
-/* @import "./css/locationbar/urlbar_border_roundness.css"; /**/
-@import "./css/locationbar/urlbar_restore_visible_border.css"; /**/
-
-/* megabar/location bar background color - [only use one at a time] ******************************/
-/* @import "./css/locationbar/urlbar_background_color.css"; /**/ /* default white background color */
-/* @import "./css/locationbar/urlbar_background_color_dark.css"; /**/ /* force dark color for e.g. dark lw-themes */
-
-/* popup content order/appearance - [only use one at a time] ************************************/
-@import "./css/locationbar/ac_popup_megabar_title_and_url_50percent_width.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_url_and_title_50percent_width.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_title_and_url_two_lines.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_url_only.css"; /**/
-
-/* result menuitem settings/appearance **********************************************************/
-@import "./css/locationbar/ac_popup_megabar_compact_results.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_searchwith_and_visit_items_hidden.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_suggest_label_hidden.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_search_engines_hidden.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_result_highlighting_aero.css"; /**/
-/* @import "./css/locationbar/ac_popup_megabar_result_separator.css"; /**/
+@import "./css/locationbar/ac_popup_megabar_compact_results.css";                   /**/
+    /*/ @import "./css/locationbar/ac_popup_megabar_searchwith_and_visit_items_hidden.css"; /**/
+    /*/ @import "./css/locationbar/ac_popup_megabar_suggest_label_hidden.css";              /**/
+    /*/ @import "./css/locationbar/ac_popup_megabar_search_engines_hidden.css";             /**/
+@import "./css/locationbar/ac_popup_megabar_result_highlighting_aero.css";          /**/
+    /*/ @import "./css/locationbar/ac_popup_megabar_result_separator.css";                  /**/
 
 
-/************************************************************************************************/
-/************************************************************************************************/
-/* Create a new file "my_userChrome.css" and add own/custom code to it. *************************/
-@import "./my_userChrome.css"; /**/
-/************************************************************************************************/
-/************************************************************************************************/
-/************************************************************************************************/
+/* Your custom styles get loaded here!
+ * Create a my_userChrome.css and fill it with your own css code 
+ */
+                                                             /* ON | OFF */ 
+@import "./my_userChrome.css";                                /**/


### PR DESCRIPTION
*Backstory: While setting up the `userChrome.css` file I toggled a few options that resulted in improper rendering of some elements, trying to toggle them back off I found myself at a total loss due to the cluttered and unreadable nature of the file. This patch aims to change that.* 

The userChrome file as it was contained `>600` lines of unformatted/poorly formated text. For such an extensive "configuration file" there must be strict formatting guidelines set in place to ensure proper visual appearance and extensibility. Through this PR I propose one such set of guidelines that has been also included in the `CONTRIBUTING.md` file. Presented below are two side-by-side comparisons of the source.

![2022-06-11_01-53gimped](https://user-images.githubusercontent.com/93952256/173429959-f9c91d85-502a-4e67-8904-fb095bdb979c.png)

![screenshotffxcssgimped](https://user-images.githubusercontent.com/93952256/173429569-2499e3f4-ded4-4683-b841-3a63a56701d5.png)

The main change I implemented is one that is a direct resolution of my aforementioned issue; the `/**/` trick used to enable comments to be toggled only on the left has been reused as a visual indicator of toggled options (`@import`ed .css files). It now acts as a 'nob' which when placed under the on/on (`/* ON | OFF */`) labels displays the current status of all the options ( [see here](#toggle-showcase) ) The entire file has also been decluttered of the inconsistent and excessive asterisks, replacing them with proper C-style comments and markdown inspired headings.

Other notable changes include:
* the readme section has been decluttered of any trailing asterisks, instead placing them in front of every containing line with compliance to C commenting standards, distinguishing them from other content in the document. Furthermore the 'basic overview' has been replaced with a proper table of contents
* the leading `/*` elements were extended to `/*/` for better user-friendliness
* grammar was improved all throughout, adding additional notes and correcting where needed.

I invite you to further review the changes made through the 'files' tab on this PR and the new guidelines I introduced in the `CONTRIBUTING` file. Any feedback/thoughts are also very much welcome.

# toggle showcase

                                       /* ON | OFF */
    @import 'foo/bar/style.css'        /**/
        /*/ @import 'bar/baz/style.css'        /**/



