### PR TITLE
Custom Default Preset: Firefox 133+ with Fixed-Width Multirow-Tabs

### DIFF
--- a/current/config/general_variables.css
+++ b/current/config/general_variables.css
@@ -34,16 +34,16 @@
   --tab_max_width: 250px !important;
   
   /* for tabs_multiple_lines.css */
-  --tab_min_width_mlt: 100px !important;
-  --tab_max_width_mlt: 200px !important;
-  --tabs-lines: 3 !important; 
+  --tab_min_width_mlt: 220px !important;
+  --tab_max_width_mlt: 220px !important;
+  --tabs-lines: 10 !important; 
 
   /* for bookmarks_toolbar_multiple_lines.css */
-  --bookmark_items_height: 22px !important; /* <- bookmark items - line height */
+  --bookmark_items_height: 26px !important; /* <- bookmark items - line height */
   --bookmark_items_lines: 3 !important; /* <- maximum amount of lines */
   
   /* for increase_ui_font_size.css */
-  --general_ui_font_size: 10pt !important;
+  --general_ui_font_size: 12pt !important;
   
   /* for searchbar_popup_engines_show_labels_scrollbars.css */
   --search-one-offs_labels_height: 100px !important;

--- a/current/css/tabs/tab_icon_unloaded_tabs_lower_opacity.css
+++ b/current/css/tabs/tab_icon_unloaded_tabs_lower_opacity.css
@@ -5,7 +5,7 @@
 
 /* Blend Inactive tabs favicon */
 :is(#TabsToolbar,#vertical-tabs) #tabbrowser-tabs .tabbrowser-tab[pending] .tab-content:not(:hover) .tab-icon-image{
-    filter: grayscale(70%);
+    filter: grayscale(50%);
     transition: filter 0.2s ease-in;
-    opacity: 0.7;
+    opacity: 0.5;
 }

--- a/current/userChrome.css
+++ b/current/userChrome.css
@@ -116,10 +116,10 @@
 */
 
 /* default 'grey' colors */
-@import "./config/color_variables.css"; /**/
+/* @import "./config/color_variables.css"; /**/
 
 /* 'AeroBlue' colors (Win 7 Aero) */
-/* @import "./config/color_variables_aero.css"; /**/
+@import "./config/color_variables_aero.css"; /**/
 
 /* 'Classic grey' colors (Win Classic) */
 /* @import "./config/color_variables_classic-grey.css"; /**/
@@ -178,14 +178,14 @@
    [!] Firefox 88 icon set uses SVG images
 */
 
-@import "./css/buttons/icons_colorized.css"; /**/
+/* @import "./css/buttons/icons_colorized.css"; /**/
 /* @import "./css/buttons/icons_white_icons.css"; /**/
 /* @import "./css/buttons/icons_custom_icons.css"; /**/
 /* @import "./css/buttons/icons_custom_icons_fx1.css"; /**/
 /* @import "./css/buttons/icons_custom_icons_fx2.css"; /**/
 /* @import "./css/buttons/icons_custom_icons_fx3.css"; /**/
 /* @import "./css/buttons/icons_custom_icons_fx3strata.css"; /**/
-/* @import "./css/buttons/icons_custom_icons_fx12_colorized.css"; /**/
+@import "./css/buttons/icons_custom_icons_fx12_colorized.css"; /**/
 /* @import "./css/buttons/icons_custom_icons_crystal.css"; /**/
 /* @import "./css/buttons/icons_custom_icons_firebird.css"; /**/
 /* @import "./css/buttons/icons_custom_icons_kempelton.css"; /**/
@@ -207,7 +207,7 @@
 */
 
 /* 'Classic' pre-Proton button padding */
-/* @import "./css/buttons/classic_button_padding.css"; /**/
+@import "./css/buttons/classic_button_padding.css"; /**/
 
 
 /* -------------------------------------
@@ -529,7 +529,7 @@
 */
 
 /* Classic tabs appearance known from Firefox 4-28 */
-@import "./css/tabs/classic_squared_tabs.css"; /**/
+/* @import "./css/tabs/classic_squared_tabs.css"; /**/
 
 /* Classic tabs appearance known from Firefox 4-28 for active tab only  */
 /* @import "./css/tabs/classic_squared_tabs_australized.css"; /**/
@@ -637,7 +637,7 @@
    [!] only compatible with 'tabs below navigation toolbar >> alt << version'
 */
 
-/* @import "./css/tabs/tabs_multiple_lines.css"; /**/
+@import "./css/tabs/tabs_multiple_lines.css"; /**/
 /* @import "./css/tabs/tabs_multiple_lines_force_newtab_button_visibility.css"; /**/
 
 
@@ -677,9 +677,9 @@
    [!] only use one option at a time
 */
 
-@import "./css/tabs/tab_close_always_visible.css"; /**/
+/* @import "./css/tabs/tab_close_always_visible.css"; /**/
 /* @import "./css/tabs/tab_close_on_active_tab_only.css"; /**/
-/* @import "./css/tabs/tab_close_show_on_hover_only.css"; /**/
+@import "./css/tabs/tab_close_show_on_hover_only.css"; /**/
 /* @import "./css/tabs/tab_close_hidden.css"; /**/
 /* @import "./css/tabs/tab_close_hidden_for_only_one_visible_tab.css"; /**/
 /* @import "./css/tabs/tab_close_at_tabs_start.css"; /**/
@@ -710,14 +710,14 @@
 /* @import "./css/tabs/classic_squared_tabs_old_bordercolor_for_lwthemes.css"; /**/ /* Has to be used along with 'classic_squared_tabs.css' */
 /* @import "./css/tabs/default_tabs_reduce_spaces.css"; /**/
 /* @import "./css/tabs/tabs_fully_squared.css"; /**/
-/* @import "./css/tabs/tab_audio_icon.css"; /**/
+@import "./css/tabs/tab_audio_icon.css"; /**/
 /* @import "./css/tabs/tab_audio_icon_colorized.css"; /**/
 /* @import "./css/tabs/tabs_container_indicator_for_classic_squared_tabs.css"; /**/
 /* @import "./css/tabs/tabs_active_tab_indicator_for_classic_squared_tabs.css"; /**/
 /* @import "./css/tabs/newtab_tab_size_equals_tab_size.css"; /**/
 /* @import "./css/tabs/newtab_button_always_visible.css"; /**/
 /* @import "./css/tabs/tab_icon_inactive_tabs_lower_opacity.css"; /**/
-/* @import "./css/tabs/tab_icon_unloaded_tabs_lower_opacity.css"; /**/
+@import "./css/tabs/tab_icon_unloaded_tabs_lower_opacity.css"; /**/
 /* @import "./css/tabs/tab_maxwidth.css"; /**/
 /* @import "./css/tabs/tab_titles_remove_blur.css"; /**/
 /* @import "./css/tabs/alltabs_button_always_visible.css"; /**/  /* hidden, if multiple tab rows are used */


### PR DESCRIPTION
This is the a nice configuration based on the [Custom CSS for Firefox](https://github.com/Aris-t2/CustomCSSforFx) mod.
Use it as-is, or as a basis for your own modifications!

Features:
- Multi-row Tabs with fixed width.
- Close-tab buttons appear only when hovering the mouse above tabs: Avoid hiding tab titles.
- Playing sound icon always visible: Easily find/mute/unmute playing tabs.
- Classic buttons.
- Firefox 133 support.

![image](https://github.com/user-attachments/assets/f31edb8f-83bf-4c73-ac6a-d50b658ce311)
