### PR TITLE
Add support for Sine.

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -1,0 +1,6 @@
+{
+  "style": {
+    "chrome": "https://raw.githubusercontent.com/Aris-t2/CustomCSSforFx/main/current/userChrome.css",
+    "content": "https://raw.githubusercontent.com/Aris-t2/CustomCSSforFx/main/current/userContent.css"
+  }
+}

--- a/theme.json
+++ b/theme.json
@@ -1,6 +1,6 @@
 {
   "style": {
-    "chrome": "https://raw.githubusercontent.com/Aris-t2/CustomCSSforFx/main/current/userChrome.css",
-    "content": "https://raw.githubusercontent.com/Aris-t2/CustomCSSforFx/main/current/userContent.css"
+    "chrome": "https://raw.githubusercontent.com/Aris-t2/CustomCSSforFx/master/current/userChrome.css",
+    "content": "https://raw.githubusercontent.com/Aris-t2/CustomCSSforFx/master/current/userContent.css"
   }
 }


### PR DESCRIPTION
I've noticed your theme and personally love it! I have created this pr so that your theme will have support for [Sine](https://github.com/CosmoCreeper/Sine). As you can probably tell from the repository, Sine does not support anything but Zen right now, but that is not the plan forever. I have an almost fully working version with cross-browser support, I just have to add some more stuff. If this pr gets merged, your theme will be installable through Sine like this:


https://github.com/user-attachments/assets/11394a22-9af8-4f90-a19c-4d60b4a2dd32

